### PR TITLE
Use pattern matching when finding front mirrors

### DIFF
--- a/lib/integrations/front.js
+++ b/lib/integrations/front.js
@@ -60,11 +60,20 @@ const getConversationMirrorId = (event) => {
 	return event.data.payload.conversation._links.self
 }
 
+const MIRROR_ID_RE = /frontapp\.com.*$/
+
 // The mirrorId can be prefixed with resin.io or api2, so we use a pattern match
 // to find matching elements by mirrorId
 const getElementByFuzzyMirrorId = (context, type, mirrorId) => {
-	const fuzzy = mirrorId.match(/frontapp\.com.*$/)[0]
-	return context.getElementByMirrorId(type, fuzzy, {
+	const mirrorIdMatches = mirrorId.match(MIRROR_ID_RE)
+	if (!mirrorIdMatches) {
+		context.log.error('Mirror ID does not match expected pattern', {
+			mirrorId,
+			pattern: MIRROR_ID_RE
+		})
+		return null
+	}
+	return context.getElementByMirrorId(type, mirrorIdMatches[0], {
 		usePattern: true
 	})
 }


### PR DESCRIPTION
This allows the front integration to find mirrors that are the same but
have a different subdomain, as the subdomain on mirror Ids from front is
unreliable. Sometimes it is api2 and sometimes it is resin.io.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>