### PR TITLE
Update js-combinatorics dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5392,9 +5392,9 @@
       "integrity": "sha1-UIEJrBQNbeQ7P4RlBs22Zd0+hzM="
     },
     "js-combinatorics": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.6.1.tgz",
-      "integrity": "sha512-VDPHc5J++qdzvngxUhOnUGwegFB9vlNzyWTD6oXKCd9qvw8NAsZdFaWK44W91U0GtBR9R0yppMgzNwTJQYymqg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-1.4.5.tgz",
+      "integrity": "sha512-lIBPgsZnIK5S8kCyTUY4L34Kq5YXj2LXyk9WJDPsK6iklV96+ZahxIsgHtXcwHhG9XZhqrS1EbnaEkUh5gyXdg==",
       "dev": true
     },
     "js-string-escape": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "express": "^4.17.1",
     "husky": "^5.0.6",
-    "js-combinatorics": "^0.6.1",
+    "js-combinatorics": "^1.4.5",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.3",
     "morgan": "^1.10.0",

--- a/test/integration/sync/scenario.js
+++ b/test/integration/sync/scenario.js
@@ -4,7 +4,6 @@
  * Proprietary and confidential.
  */
 
-const combinatorics = require('js-combinatorics')
 const nock = require('nock')
 const Bluebird = require('bluebird')
 const {
@@ -30,9 +29,8 @@ const tailSort = [
 
 const getVariations = (sequence, options = {}) => {
 	const invariant = _.last(sequence)
-	return combinatorics
-		.permutationCombination(sequence)
-		.toArray()
+	return Array
+		.from(new utils.PermutationCombination(sequence))
 		.filter((combination) => {
 			return _.includes(combination, invariant)
 		})

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -4,6 +4,7 @@
  * Proprietary and confidential.
  */
 
+const combinatorics = require('js-combinatorics/commonjs/combinatorics')
 const {
 	v4: uuid
 } = require('uuid')
@@ -25,4 +26,19 @@ exports.generateRandomSlug = (options = {}) => {
 	}
 
 	return slug
+}
+
+exports.PermutationCombination = class PermutationCombination {
+	constructor (seed) {
+		this.seed = [ ...seed ]
+	}
+
+	[Symbol.iterator] () {
+		return (function *(it) {
+			// eslint-disable-next-line id-length
+			for (let index = 1, l = it.length; index <= l; index++) {
+				yield * new combinatorics.Permutation(it, index)
+			}
+		}(this.seed))
+	}
 }


### PR DESCRIPTION
v1 removes the `permutationCombination` method so we define a `PermutationCombination` class as per the README of the js-combinatorics repo - https://github.com/dankogai/js-combinatorics#whats-missing-from-version-0x

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>