### PR TITLE
Remove Balena Chat view

### DIFF
--- a/lib/cards/balena/view-balena-chat.json
+++ b/lib/cards/balena/view-balena-chat.json
@@ -2,6 +2,7 @@
   "slug": "view-balena-chat",
   "name": "Balena chat",
   "type": "view@1.0.0",
+  "active": false,
   "markers": [ "org-balena" ],
   "data": {
     "namespace": "Comms",


### PR DESCRIPTION
This view is no longer used and just confuses users and clutters the sidebar.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>