### PR TITLE
Add 'ongoing' as a brainstorm-topic status option

### DIFF
--- a/lib/cards/contrib/brainstorm-topic.js
+++ b/lib/cards/contrib/brainstorm-topic.js
@@ -6,10 +6,17 @@
 
 const SLUG = 'brainstorm-topic'
 
+const statusOptions = [
+	'open',
+	'ongoing',
+	'closed',
+	'archived'
+]
+
 module.exports = ({
 	mixin, withEvents, withRelationships, asPipelineItem
 }) => {
-	return mixin(withEvents, withRelationships(SLUG), asPipelineItem)({
+	return mixin(withEvents, withRelationships(SLUG), asPipelineItem(statusOptions))({
 		slug: SLUG,
 		name: 'Brainstorm Topic',
 		type: 'type@1.0.0',

--- a/lib/cards/contrib/sales-thread.js
+++ b/lib/cards/contrib/sales-thread.js
@@ -10,7 +10,7 @@ const SLUG = 'sales-thread'
 module.exports = ({
 	mixin, uiSchemaDef, asPipelineItem, withRelationships
 }) => {
-	return mixin(asPipelineItem, withRelationships(SLUG))({
+	return mixin(asPipelineItem(), withRelationships(SLUG))({
 		slug: SLUG,
 		name: 'Sales Thread',
 		type: 'type@1.0.0',

--- a/lib/cards/contrib/support-thread.js
+++ b/lib/cards/contrib/support-thread.js
@@ -9,7 +9,7 @@
 module.exports = ({
 	mixin, withEvents, uiSchemaDef, asPipelineItem
 }) => {
-	return mixin(withEvents, asPipelineItem)({
+	return mixin(withEvents, asPipelineItem())({
 		slug: 'support-thread',
 		name: 'Support Thread',
 		type: 'type@1.0.0',

--- a/lib/cards/mixins/as-pipeline-item.js
+++ b/lib/cards/mixins/as-pipeline-item.js
@@ -4,43 +4,47 @@
  * Proprietary and confidential.
  */
 
+const defaultStatusOptions = [
+	'open',
+	'closed',
+	'archived'
+]
+
 // Defines fields common to all items used in pipelines
-module.exports = {
-	data: {
-		schema: {
-			properties: {
-				data: {
-					type: 'object',
-					properties: {
+module.exports = (statusOptions = defaultStatusOptions) => {
+	return {
+		data: {
+			schema: {
+				properties: {
+					data: {
+						type: 'object',
+						properties: {
+							status: {
+								title: 'Status',
+								type: 'string',
+								default: 'open',
+								enum: statusOptions
+							}
+						}
+					}
+				},
+				required: [ 'data' ]
+			},
+			uiSchema: {
+				fields: {
+					data: {
 						status: {
-							title: 'Status',
-							type: 'string',
-							default: 'open',
-							enum: [
-								'open',
-								'closed',
-								'archived'
-							]
+							'ui:widget': 'Badge'
 						}
 					}
 				}
 			},
-			required: [ 'data' ]
-		},
-		uiSchema: {
-			fields: {
-				data: {
-					status: {
-						'ui:widget': 'Badge'
-					}
-				}
-			}
-		},
-		slices: [
-			'properties.data.properties.status'
-		],
-		indexed_fields: [
-			[ 'data.status' ]
-		]
+			slices: [
+				'properties.data.properties.status'
+			],
+			indexed_fields: [
+				[ 'data.status' ]
+			]
+		}
 	}
 }


### PR DESCRIPTION
This change actually requires a small tweak to how the `asPipelineItem` mixin works. It is now exported as a function that takes an optional list of strings representing the possible status options. The default status options remain as 'open', 'closed' and 'archived'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![image](https://user-images.githubusercontent.com/2925657/105985069-90de9300-60cd-11eb-8621-3c2b5d9ae49f.png)
