### PR TITLE
Set default status of GitHub issue to 'open'

### DIFF
--- a/lib/cards/contrib/issue.js
+++ b/lib/cards/contrib/issue.js
@@ -41,6 +41,7 @@ module.exports = ({
 							status: {
 								title: 'Status',
 								type: 'string',
+								default: 'open',
 								enum: [
 									'open',
 									'closed'


### PR DESCRIPTION
Fixes https://github.com/product-os/jellyfish/issues/4689

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>