### PR TITLE
Re-instate status slice in opportunity type card

### DIFF
--- a/lib/cards/contrib/opportunity.js
+++ b/lib/cards/contrib/opportunity.js
@@ -94,7 +94,10 @@ module.exports = ({
 						}
 					}
 				}
-			}
+			},
+			slices: [
+				'properties.data.properties.status'
+			]
 		}
 	})
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch graham@balena.io
***

Now that [slices are handled better in views](https://github.com/product-os/jellyfish/pull/5619) we can re-instate the status slice for opportunities!