### PR TITLE
Add mentionsUser to brainstorm-topic snippet view mode

### DIFF
--- a/lib/cards/contrib/brainstorm-topic.js
+++ b/lib/cards/contrib/brainstorm-topic.js
@@ -14,7 +14,7 @@ const statusOptions = [
 ]
 
 module.exports = ({
-	mixin, withEvents, withRelationships, asPipelineItem
+	mixin, uiSchemaDef, withEvents, withRelationships, asPipelineItem
 }) => {
 	return mixin(withEvents, withRelationships(SLUG), asPipelineItem(statusOptions))({
 		slug: SLUG,
@@ -53,9 +53,14 @@ module.exports = ({
 				snippet: {
 					data: {
 						'ui:order': [
+							'mentionsUser',
 							'status',
 							'category'
 						],
+						mentionsUser: {
+							$ref: uiSchemaDef('usernameList'),
+							'ui:title': null
+						},
 						status: {
 							'ui:title': null,
 							'ui:widget': 'Badge'


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR adds the list of mentioned users in a brainstorm topic to the 'snippet' view mode (used when the brainstorm-topic is displayed in a list). The username for each mentioned user is displayed as a hyperlink in a comma-separated list.

[Flowdock thread ref](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/oO4DouwY41c02S0zUJfOJTMWatp)

>...a common question people have every week is when looking at the agenda for a brainstorm call, how to tell what topics they are involved with, without going through each item in the list one by one - do you guys have any thoughts on a solution for this? adding all the mentions to the topic listing seems like it would do the trick but are we able to separate out the mentions and reporter from the topic description?