### PR TITLE
Improve brainstorm-call and brainstorm-topic cards

### DIFF
--- a/lib/cards/contrib/brainstorm-call.js
+++ b/lib/cards/contrib/brainstorm-call.js
@@ -4,13 +4,13 @@
  * Proprietary and confidential.
  */
 
+const SLUG = 'brainstorm-call'
+
 module.exports = ({
-	mixin, withEvents
+	mixin, uiSchemaDef, withEvents, withRelationships
 }) => {
-	return mixin(
-		withEvents
-	)({
-		slug: 'brainstorm-call',
+	return mixin(withEvents, withRelationships(SLUG))({
+		slug: SLUG,
 		name: 'Brainstorm Call',
 		type: 'type@1.0.0',
 		markers: [],
@@ -23,20 +23,36 @@ module.exports = ({
 						fullTextSearch: true
 					},
 					data: {
-						type: 'object'
+						type: 'object',
+						properties: {
+							datetime: {
+								title: 'Meeting date/time',
+								type: 'string',
+								format: 'date-time'
+							}
+						},
+						required: [ 'datetime' ]
 					}
 				}
 			},
-			required: [ 'name', 'data' ],
-			meta: {
-				relationships: [
-					{
-						title: 'Topics',
-						link: 'has attached',
-						type: 'brainstorm-topic'
+			uiSchema: {
+				snippet: {
+					data: {
+						datetime: {
+							$ref: uiSchemaDef('dateTime'),
+							'ui:title': null
+						}
 					}
-				]
-			}
+				},
+				fields: {
+					data: {
+						datetime: {
+							$ref: uiSchemaDef('dateTime')
+						}
+					}
+				}
+			},
+			required: [ 'name', 'data' ]
 		}
 	})
 }

--- a/lib/cards/contrib/brainstorm-topic.js
+++ b/lib/cards/contrib/brainstorm-topic.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+/* eslint-disable no-template-curly-in-string */
+
 const SLUG = 'brainstorm-topic'
 
 const statusOptions = [
@@ -35,7 +37,13 @@ module.exports = ({
 					},
 					data: {
 						type: 'object',
+						required: [ 'reporter', 'category', 'description' ],
 						properties: {
+							reporter: {
+								type: 'string',
+								pattern: '^[a-z0-9-]+$',
+								fullTextSearch: true
+							},
 							category: {
 								type: 'string',
 								fullTextSearch: true
@@ -44,6 +52,11 @@ module.exports = ({
 								type: 'string',
 								format: 'markdown',
 								fullTextSearch: true
+							},
+							flowdockThreadUrl: {
+								type: 'string',
+								format: 'uri',
+								title: 'Flowdock Thread URL'
 							}
 						}
 					}
@@ -53,13 +66,24 @@ module.exports = ({
 				snippet: {
 					data: {
 						'ui:order': [
+							'reporter',
 							'mentionsUser',
 							'status',
 							'category'
 						],
+						reporter: {
+							'ui:widget': 'Link',
+							'ui:value': '${source[5:]},',
+							'ui:options': {
+								href: 'https://jel.ly.fish/${source}',
+								flexDirection: 'row'
+							}
+						},
 						mentionsUser: {
 							$ref: uiSchemaDef('usernameList'),
-							'ui:title': null
+							'ui:options': {
+								flexDirection: 'row'
+							}
 						},
 						status: {
 							'ui:title': null,
@@ -73,8 +97,28 @@ module.exports = ({
 				},
 				fields: {
 					data: {
+						'ui:order': [
+							'reporter',
+							'mentionsUser',
+							'status',
+							'category',
+							'description',
+							'flowdockThreadUrl'
+						],
 						category: {
 							'ui:widget': 'HighlightedName'
+						},
+						reporter: {
+							'ui:widget': 'Link',
+							'ui:value': '${source[5:]},',
+							'ui:options': {
+								href: 'https://jel.ly.fish/${source}'
+							}
+						},
+						flowdockThreadUrl: {
+							'ui:options': {
+								blank: true
+							}
 						}
 					}
 				},
@@ -92,6 +136,13 @@ module.exports = ({
 								'ui:options': {
 									resource: 'brainstorm-topic',
 									keyPath: 'data.category'
+								}
+							},
+							reporter: {
+								'ui:widget': 'AutoCompleteWidget',
+								'ui:options': {
+									resource: 'user',
+									keyPath: 'slug'
 								}
 							}
 						}


### PR DESCRIPTION
Added reporter and flowdockThreadUrl fields to brainstorm-topic (with ui-schema)
Added datetime field to brainstorm-call (with ui-schema)
Made use of withRelationships mixin in brainstorm-call

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

### Brainstorm Topics
![image](https://user-images.githubusercontent.com/2925657/107475042-14a47f00-6ba6-11eb-9f73-44891ee21abd.png)

### Brainstorm Calls
![image](https://user-images.githubusercontent.com/2925657/107475100-2be36c80-6ba6-11eb-8373-984ee56192a2.png)

### NOTE

This change assumes that reporter (if set) is in the format `user-xyz` (as opposed to just `xyz`). I've [made a change to hubot-as-mainbot](https://github.com/balena-io/hubot-as-mainbot/pull/693) that sets the reporter value appropriately. E.g. 
```
reporter: `user-${message.user.name.toLowerCase()}`
```

After this hubot-as-mainbot change was deployed, I ran a little script that patched all existing brainstorm-topic cards:
```js
let updateBrainstormTopicReporters = async () => {
  const brainstormTopics = await window.sdk.query({
    type: 'object',
    required: [ 'type' ],
    properties: {
      type: {
        type: 'string',
        const: 'brainstorm-topic@1.0.0'
      },
      data: {
        required: [ 'reporter' ],
        properties: {
          reporter: {
            type: 'string'
          }
        }
      }
    }
  })

  brainstormTopics.forEach(async (topic) => {
    if (topic.data.reporter) {
      console.log(`Replacing reporter '${topic.data.reporter}' in ${topic.name}`)
      await window.sdk.card.update(topic.id, topic.type, [
        {
          op: 'add',
          path: '/data/reporter',
          value: `user-${topic.data.reporter.toLowerCase().replace('user-', '')}`
        }
      ])
    }
  })
}
```