### PR TITLE
Add fullTextSearch indexes to mirrors fields

### DIFF
--- a/lib/cards/contrib/sales-thread.js
+++ b/lib/cards/contrib/sales-thread.js
@@ -44,7 +44,8 @@ module.exports = ({
 								type: 'array',
 								items: {
 									type: 'string'
-								}
+								},
+								fullTextSearch: true
 							},
 							inbox: {
 								type: 'string',

--- a/lib/cards/contrib/support-thread.js
+++ b/lib/cards/contrib/support-thread.js
@@ -47,7 +47,8 @@ module.exports = ({
 								type: 'array',
 								items: {
 									type: 'string'
-								}
+								},
+								fullTextSearch: true
 							},
 							environment: {
 								type: 'string',


### PR DESCRIPTION
support-thread.data.mirrors
sales-thread.data.mirrors

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This should make it easier/faster to query for values in arrays of strings, like the mirror URL of a support/sales thread.