### PR TITLE
Add fullTextSearch indexes to GH cards

### DIFF
--- a/lib/cards/contrib/issue.js
+++ b/lib/cards/contrib/issue.js
@@ -20,7 +20,8 @@ module.exports = ({
 				properties: {
 					name: {
 						type: 'string',
-						pattern: '^.*\\S.*$'
+						pattern: '^.*\\S.*$',
+						fullTextSearch: true
 					},
 					data: {
 						type: 'object',
@@ -32,7 +33,8 @@ module.exports = ({
 								type: 'array',
 								items: {
 									type: 'string'
-								}
+								},
+								fullTextSearch: true
 							},
 							description: {
 								type: 'string',

--- a/lib/cards/contrib/pull-request.js
+++ b/lib/cards/contrib/pull-request.js
@@ -19,7 +19,8 @@ module.exports = ({
 				properties: {
 					name: {
 						type: 'string',
-						pattern: '^.*\\S.*$'
+						pattern: '^.*\\S.*$',
+						fullTextSearch: true
 					},
 					data: {
 						type: 'object',
@@ -79,7 +80,15 @@ module.exports = ({
 								type: [ 'string', 'null' ]
 							},
 							repository: {
-								type: 'string'
+								type: 'string',
+								fullTextSearch: true
+							},
+							mirrors: {
+								type: 'array',
+								items: {
+									type: 'string'
+								},
+								fullTextSearch: true
 							}
 						}
 					}


### PR DESCRIPTION
issue.name
issue.data.mirrors
pull-request.name
pull-request.repository
pull-request.mirrors

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This should make it easier/faster to query for values in arrays of strings, like the mirror URL of an issue/pull-request.