### PR TITLE
Add new integration test file to test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ test-translate:
 	FILES="'./test/integration/sync/typeform-translate.spec.js'" make test
 	INTEGRATION_FRONT_TOKEN=foobar FILES="'./test/integration/sync/front-translate.spec.js'" make test
 	FILES="'./test/integration/sync/discourse-translate.spec.js'" make test
+	FILES="'./test/integration/sync/discourse.spec.js'" make test
 
 test-mirror:
 	FILES="'./test/integration/sync/*-mirror.spec.js'" make test

--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -84,6 +84,6 @@ tasks:
     required: true
     environment:
       - name: 'FILES'
-        value: './test/integration/sync/discourse-translate.spec.js'
+        value: './test/integration/sync/discourse*.spec.js'
     dependencies:
       - 'outreach-translate'


### PR DESCRIPTION
This was omitted previously as I forgot we explicitly name the integration test files we are running!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>