### PR TITLE
Remove references to obsolete form-response type

### DIFF
--- a/lib/cards/mixins/test/fixtures/constraints-subset.js
+++ b/lib/cards/mixins/test/fixtures/constraints-subset.js
@@ -86,16 +86,6 @@ module.exports = [
 		}
 	},
 	{
-		slug: 'link-constraint-issue-is-attached-to-form-response',
-		name: 'is attached',
-		data: {
-			title: 'Form Response',
-			from: 'issue',
-			to: 'form-response',
-			inverse: 'link-constraint-form-response-has-attached-issue'
-		}
-	},
-	{
 		slug: 'link-constraint-issue-is-attached-to-user-feedback',
 		name: 'is attached to',
 		data: {

--- a/lib/cards/mixins/test/fixtures/expected-filtered.json
+++ b/lib/cards/mixins/test/fixtures/expected-filtered.json
@@ -19,11 +19,6 @@
           "title": "Specifications"
         },
         {
-          "link": "is attached",
-          "type": "form-response",
-          "title": "Form Responses"
-        },
-        {
           "link": "is attached to",
           "type": "user-feedback",
           "title": "User Feedbacks"

--- a/lib/cards/mixins/test/fixtures/expected.json
+++ b/lib/cards/mixins/test/fixtures/expected.json
@@ -29,11 +29,6 @@
           "title": "Specifications"
         },
         {
-          "link": "is attached",
-          "type": "form-response",
-          "title": "Form Responses"
-        },
-        {
           "link": "is attached to",
           "type": "user-feedback",
           "title": "User Feedbacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-2.15.0.tgz",
-      "integrity": "sha512-KXy5SXc1yZcDrFL19iifI8Dngm6zAE17CBoBKM7PR9JmNaQ8iKuSXjU8q1VA6kiT92RoESooPtSjfAwi73+g1A==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-2.16.1.tgz",
+      "integrity": "sha512-USVR0FIpBMXUha4j6JyXng5L+8te5PNankYC8dRpkqeGMW6YC75+IDQ2fAAttLeYODzDZRQRABtYtUDcKZJoYQ==",
       "requires": {
         "axios": "^0.21.1",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.0.61",
-    "@balena/jellyfish-client-sdk": "^2.15.0",
+    "@balena/jellyfish-client-sdk": "^2.16.1",
     "@balena/jellyfish-environment": "^2.4.22",
     "@balena/jellyfish-logger": "1.0.39",
     "@balena/jellyfish-plugin-base": "^1.2.28",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

The form response card has been removed, including link constraints that reference it.