### PR TITLE
Add new chart-configuration type card

### DIFF
--- a/lib/cards/contrib/chart-configuration.js
+++ b/lib/cards/contrib/chart-configuration.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+const SLUG = 'chart-configuration'
+
+module.exports = ({
+	mixin, withRelationships
+}) => {
+	return mixin(withRelationships(SLUG))({
+		slug: SLUG,
+		name: 'Chart configuration',
+		type: 'type@1.0.0',
+		data: {
+			schema: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+						fullTextSearch: true
+					},
+					data: {
+						type: 'object',
+						properties: {
+							description: {
+								type: 'string'
+							},
+							chartingLibrary: {
+								title: 'Charting library',
+								type: 'string',
+								enum: [ 'plotly' ],
+								default: 'plotly'
+							},
+							settings: {
+								type: 'string'
+							}
+						},
+						required: [
+							'chartingLibrary',
+							'settings'
+						]
+					}
+				},
+				required: [
+					'name',
+					'data'
+				]
+			}
+		}
+	})
+}

--- a/lib/cards/index.js
+++ b/lib/cards/index.js
@@ -26,6 +26,7 @@ module.exports = [
 	require('./contrib/brainstorm-call.js'),
 	require('./contrib/brainstorm-topic'),
 	require('./contrib/changelog.js'),
+	require('./contrib/chart-configuration.js'),
 	require('./contrib/checkin.js'),
 	require('./contrib/contact.js'),
 	require('./contrib/email-sequence.json'),


### PR DESCRIPTION
This will be used to save chart configuration - initially just for Plotly but other chart libraries could be supported.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>