### PR TITLE
Remove incorrect filter on $$links from product improvements view

### DIFF
--- a/lib/cards/balena/view-all-product-improvements.json
+++ b/lib/cards/balena/view-all-product-improvements.json
@@ -8,11 +8,6 @@
       {
         "name": "All Product Improvements",
         "schema": {
-          "$$links": {
-            "has attached": {
-              "type": "object"
-            }
-          },
           "type": "object",
           "properties": {
             "type": {


### PR DESCRIPTION
This item in the schema was preventing any product improvements showing up in the list unless they were attached to another card.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>