### PR TITLE
brainstorm-topic.data.reporter now uses username UI schema def

### DIFF
--- a/lib/cards/contrib/brainstorm-topic.js
+++ b/lib/cards/contrib/brainstorm-topic.js
@@ -72,10 +72,8 @@ module.exports = ({
 							'category'
 						],
 						reporter: {
-							'ui:widget': 'Link',
-							'ui:value': '${source[5:]},',
+							$ref: uiSchemaDef('username'),
 							'ui:options': {
-								href: 'https://jel.ly.fish/${source}',
 								flexDirection: 'row'
 							}
 						},
@@ -109,11 +107,7 @@ module.exports = ({
 							'ui:widget': 'HighlightedName'
 						},
 						reporter: {
-							'ui:widget': 'Link',
-							'ui:value': '${source[5:]},',
-							'ui:options': {
-								href: 'https://jel.ly.fish/${source}'
-							}
+							$ref: uiSchemaDef('username')
 						},
 						flowdockThreadUrl: {
 							'ui:options': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,25 +293,25 @@
       }
     },
     "@balena/jellyfish-core": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.0.3.tgz",
-      "integrity": "sha512-gfizQTk5ZXL1p4xTCBQ/uEWwPKXjMJ8cKe7dKxqbX9XVh3+FRguL8RJu+std82yMK2119nKmJobEcMZ+9wkDnw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-core/-/jellyfish-core-2.8.0.tgz",
+      "integrity": "sha512-w4EDInIEdwARf+bvQCVM8UmcjpP4nqPW7cckVrvwZTxMEA0NDtkYYgrZR9sN1eZr7eQKyLvD+mhBAzfm3ZITLw==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-assert": "^1.0.58",
-        "@balena/jellyfish-environment": "^2.4.12",
-        "@balena/jellyfish-logger": "^1.0.23",
-        "@balena/jellyfish-metrics": "^0.1.86",
-        "@balena/jellyfish-uuid": "^1.0.62",
+        "@balena/jellyfish-assert": "^1.0.62",
+        "@balena/jellyfish-environment": "^2.4.23",
+        "@balena/jellyfish-logger": "^1.0.43",
+        "@balena/jellyfish-metrics": "^0.1.109",
+        "@balena/jellyfish-uuid": "^1.0.71",
         "bluebird": "^3.7.2",
         "debounce-promise": "^3.1.2",
         "fast-equals": "^2.0.0",
         "fast-json-patch": "^2.2.1",
         "json-e": "^4.3.0",
         "json-schema-deref-sync": "^0.14.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "pg-format": "^1.0.4",
-        "pg-promise": "^10.9.2",
+        "pg-promise": "^10.9.4",
         "redis": "^3.0.2",
         "redis-mock": "^0.56.3",
         "skhema": "^5.3.3",
@@ -320,16 +320,16 @@
       },
       "dependencies": {
         "@balena/jellyfish-metrics": {
-          "version": "0.1.86",
-          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-0.1.86.tgz",
-          "integrity": "sha512-ocaeWzrt+SSbAVXF5esrOZzNcI4Swv69Nmc66S7Pt9VMgd7WRsaiMZlqiKyMO4XGdls2vBoM3tVi8mun13/FtQ==",
+          "version": "0.1.110",
+          "resolved": "https://registry.npmjs.org/@balena/jellyfish-metrics/-/jellyfish-metrics-0.1.110.tgz",
+          "integrity": "sha512-4AsQP/jvFWTQHfNhxWJeu2YZTho7BJ8j7i83jhoeRBlGcJ7qPrcN8wCWRgjQohYh2gX7eLSyzvKXbDIfJFGR2w==",
           "dev": true,
           "requires": {
-            "@balena/jellyfish-environment": "^2.4.12",
-            "@balena/jellyfish-logger": "^1.0.23",
+            "@balena/jellyfish-environment": "^2.4.23",
+            "@balena/jellyfish-logger": "^1.0.43",
             "@balena/node-metrics-gatherer": "^5.7.3",
             "express": "^4.17.1",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.21"
           }
         },
         "fast-deep-equal": {
@@ -7156,9 +7156,9 @@
       "dev": true
     },
     "pg-promise": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.9.2.tgz",
-      "integrity": "sha512-ewelfzZeSPe5sbgd5ylB6edVXqoD8AH/fqZj4wPLL0242vXtkFY3JuUqt3mfvTruOqZHhoINpoXTfmC9UXbZ7A==",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.9.4.tgz",
+      "integrity": "sha512-LvsKCb3mbeqHxFXFLSHVkRM8WKS067YIjFLVYsfR/z4InTEJcYL4pr2nwGK/WGLE4qNEhRMR9PIEAhjsjggX/A==",
       "dev": true,
       "requires": {
         "assert-options": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@balena/ci-task-runner": "^0.2.110",
     "@balena/jellycheck": "^0.1.1",
     "@balena/jellyfish-action-library": "^8.0.22",
-    "@balena/jellyfish-core": "^2.0.3",
+    "@balena/jellyfish-core": "^2.8.0",
     "@balena/jellyfish-sync": "^5.2.0",
     "@balena/jellyfish-test-harness": "^1.1.0",
     "ava": "^3.15.0",


### PR DESCRIPTION
Depends on https://github.com/product-os/jellyfish-core/pull/521

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>