### PR TITLE
Use JSONpatch for thread Front translates

### DIFF
--- a/lib/integrations/front.js
+++ b/lib/integrations/front.js
@@ -16,6 +16,7 @@ const request = require('request-promise')
 const utils = require('./utils')
 const assert = require('@balena/jellyfish-assert')
 const LRU = require('lru-cache')
+const jsonpatch = require('fast-json-patch')
 
 /**
  * @summary All the thread types we support
@@ -560,20 +561,25 @@ const findValidInbox = (inboxes) => {
 }
 
 /**
- * @summary Get a delta to apply to the thread card
+ * @summary Get a set of patches to apply to the thread card
  * @function
  * @private
  *
+ * @param {Object} card - thread card
  * @param {Object} event - external event
- * @returns {Object} delta
+ * @returns {Array} set of json patch objects
  */
-const getThreadDeltaFromEvent = (event) => {
-	const delta = {}
-	delta.tags = event.data.payload.conversation.tags.map((tag) => {
+const getThreadPatchFromEvent = (card, event) => {
+	const tags = event.data.payload.conversation.tags.map((tag) => {
 		return tag.name
 	})
+	const patch = jsonpatch.compare({
+		tags: card.tags || []
+	}, {
+		tags
+	})
 
-	return delta
+	return patch
 }
 
 /**
@@ -997,8 +1003,9 @@ module.exports = class FrontIntegration {
 		cards.push(...lastMessage)
 
 		const date = utils.getDateFromEpoch(event.data.payload.emitted_at)
-		const delta = getThreadDeltaFromEvent(event)
-		const updatedThreadCard = utils.patchObject(threadCard, delta)
+		const patch = getThreadPatchFromEvent(threadCard, event)
+		const updatedThreadCard = _.cloneDeep(threadCard)
+		jsonpatch.applyPatch(updatedThreadCard, patch)
 
 		if (updatedThreadCard.data.translateDate &&
 				date < new Date(updatedThreadCard.data.translateDate)) {
@@ -1026,12 +1033,20 @@ module.exports = class FrontIntegration {
 					}
 				}
 
-				updatedThreadCard.data.translateDate = date.toISOString()
+				patch.unshift({
+					op: 'replace',
+					path: '/data/translateDate',
+					value: date.toISOString()
+				})
 				return cards.concat([
 					{
 						time: date,
 						actor,
-						card: updatedThreadCard
+						card: {
+							id: updatedThreadCard.id,
+							type: updatedThreadCard.type,
+							patch
+						}
 					}
 				])
 			}
@@ -1039,7 +1054,11 @@ module.exports = class FrontIntegration {
 			return cards
 		}
 
-		updatedThreadCard.data.translateDate = date.toISOString()
+		patch.unshift({
+			op: 'replace',
+			path: '/data/translateDate',
+			value: date.toISOString()
+		})
 
 		// We make a good enough approximation if we didn't know about the head
 		// card, as Front won't tell us precisely when the event happened.
@@ -1050,7 +1069,11 @@ module.exports = class FrontIntegration {
 			{
 				time: _.isString(threadCard.id) ? date : creationDate,
 				actor,
-				card: updatedThreadCard
+				card: {
+					id: updatedThreadCard.id,
+					type: updatedThreadCard.type,
+					patch
+				}
 			}
 		])
 	}

--- a/lib/integrations/utils.js
+++ b/lib/integrations/utils.js
@@ -34,28 +34,6 @@ exports.getDateFromEpoch = (epoch) => {
 	return new Date(epoch * 1000)
 }
 
-/**
- * @summary Patch an object
- * @function
- * @private
- *
- * @param {Object} object - source object
- * @param {Object} delta - change delta
- * @returns {Object} patched object
- */
-exports.patchObject = (object, delta) => {
-	return _.mergeWith(_.cloneDeep(object), delta, (objectValue, sourceValue) => {
-		// Always do array overrides
-		if (_.isArray(sourceValue)) {
-			return sourceValue
-		}
-
-		// _.mergeWith expected undefined
-		// eslint-disable-next-line no-undefined
-		return undefined
-	})
-}
-
 exports.attachCards = (date, fromCard, toCard, options) => {
 	return {
 		time: date,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@octokit/plugin-throttling": "^3.4.1",
     "@octokit/rest": "^18.3.5",
     "bluebird": "^3.7.2",
+    "fast-json-patch": "^3.0.0-1",
     "front-sdk": "^0.8.1",
     "geoip-lite": "^1.4.2",
     "intercom-client": "^2.11.0",


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Generate JSON patch objects for Front-synced support threads to work with https://github.com/product-os/jellyfish-sync/pull/552 and https://github.com/product-os/jellyfish-sync/pull/553

Depends on https://github.com/product-os/jellyfish-plugin-default/pull/272