### PR TITLE
Make status field required in 'pipeline' contracts

### DIFF
--- a/lib/cards/mixins/as-pipeline-item.js
+++ b/lib/cards/mixins/as-pipeline-item.js
@@ -18,6 +18,7 @@ module.exports = (statusOptions = defaultStatusOptions) => {
 				properties: {
 					data: {
 						type: 'object',
+						required: [ 'status' ],
 						properties: {
 							status: {
 								title: 'Status',


### PR DESCRIPTION
This makes it clear in the UI form that this field is required.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Note - as the status field is of type `'string'` with no null option, the status field is effectively required anyway. This change should just ensure that `react-jsonschema-form` adds the `*` after the `Status` field name in forms, making it clearer to the user that this field is required.
