### PR TITLE
Remove redundant phase field in improvement contract

### DIFF
--- a/lib/cards/contrib/product-improvement.js
+++ b/lib/cards/contrib/product-improvement.js
@@ -51,62 +51,8 @@ module.exports = ({
 								type: 'string',
 								format: 'markdown',
 								default: DEFAULT_CONTENT
-							},
-							phase: {
-								title: 'Phase',
-								type: 'string',
-								default: 'proposed',
-								oneOf: [
-									{
-										title: 'Proposed',
-										const: 'proposed'
-									},
-									{
-										title: 'Waiting',
-										const: 'waiting'
-									},
-									{
-										title: 'Researching (Drafting Spec)',
-										const: 'researching'
-									},
-									{
-										title: 'Candidate spec',
-										const: 'candidate-spec'
-									},
-									{
-										title: 'Assigned resources',
-										const: 'assigned-resources'
-									},
-									{
-										title: 'Implementation',
-										const: 'implementation'
-									},
-									{
-										title: 'All milestones completed',
-										const: 'all-milestones-completed'
-									},
-									{
-										title: 'Finalising and testing',
-										const: 'finalising-and-testing'
-									},
-									{
-										title: 'Merged',
-										const: 'merged'
-									},
-									{
-										title: 'Released',
-										const: 'released'
-									},
-									{
-										title: 'Denied or Failed',
-										const: 'denied-or-failed'
-									}
-								]
 							}
-						},
-						required: [
-							'phase'
-						]
+						}
 					}
 				},
 				required: [
@@ -117,7 +63,7 @@ module.exports = ({
 			uiSchema: {
 				fields: {
 					data: {
-						'ui:order': [ 'status', 'phase', 'specification', 'description' ]
+						'ui:order': [ 'status', 'specification', 'description' ]
 					}
 				}
 			}


### PR DESCRIPTION
This field has been superceded by the status field. All current product-improvement contracts have been migrated so that the status field matches the phase field.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>