### PR TITLE
Display milestone status in snippet view

### DIFF
--- a/lib/cards/contrib/milestone.js
+++ b/lib/cards/contrib/milestone.js
@@ -24,6 +24,16 @@ module.exports = ({
 					}
 				},
 				required: [ 'name' ]
+			},
+			uiSchema: {
+				snippet: {
+					data: {
+						status: {
+							'ui:title': null,
+							'ui:widget': 'Badge'
+						}
+					}
+				}
 			}
 		}
 	})


### PR DESCRIPTION
The status field is now exposed on the snippet view of milestone cards (i.e. when they are in a list).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![image](https://user-images.githubusercontent.com/2925657/118918266-bdf4d100-b95c-11eb-9432-13609e49252a.png)
