### PR TITLE
Specify enum names for improvement status values

### DIFF
--- a/lib/cards/contrib/product-improvement.js
+++ b/lib/cards/contrib/product-improvement.js
@@ -24,10 +24,28 @@ const statusOptions = [
 	'denied-or-failed'
 ]
 
+const statusNames = [
+	'Proposed',
+	'Waiting',
+	'Researching (Drafting Spec)',
+	'Candidate spec',
+	'Assigned resources',
+	'Implementation',
+	'All milestones completed',
+	'Finalising and testing',
+	'Merged',
+	'Released',
+	'Denied or Failed'
+]
+
 module.exports = ({
 	mixin, withEvents, withRelationships, asPipelineItem
 }) => {
-	return mixin(withEvents, withRelationships(SLUG), asPipelineItem(statusOptions))({
+	return mixin(
+		withEvents,
+		withRelationships(SLUG),
+		asPipelineItem(statusOptions, statusOptions[0], statusNames)
+	)({
 		slug: SLUG,
 		name: 'Product improvement',
 		type: 'type@1.0.0',

--- a/lib/cards/mixins/as-pipeline-item.js
+++ b/lib/cards/mixins/as-pipeline-item.js
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
+
 const defaultStatusOptions = [
 	'open',
 	'closed',
@@ -11,7 +13,11 @@ const defaultStatusOptions = [
 ]
 
 // Defines fields common to all items used in pipelines
-module.exports = (statusOptions = defaultStatusOptions) => {
+module.exports = (
+	statusOptions = defaultStatusOptions,
+	defaultStatus = 'open',
+	statusNames = null
+) => {
 	return {
 		data: {
 			schema: {
@@ -23,8 +29,9 @@ module.exports = (statusOptions = defaultStatusOptions) => {
 							status: {
 								title: 'Status',
 								type: 'string',
-								default: 'open',
-								enum: statusOptions
+								default: defaultStatus,
+								enum: statusOptions,
+								enumNames: statusNames || statusOptions.map(_.startCase)
 							}
 						}
 					}


### PR DESCRIPTION
product-improvement is the only use of `asPipelineItem` that requires enumNames to be overwritten.

Note - as a related fix we should update jellyfish-ui-component's getViewSlices helper method to make use of the `enumNames` (if defined) to return the appropriate value name (label) as well. That way we can make use of it when displaying the Status dropdown component in the View header.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***
Before: 
![image](https://user-images.githubusercontent.com/2925657/118922127-a836da00-b963-11eb-9708-9a88f97aa586.png)

After:
![image](https://user-images.githubusercontent.com/2925657/118921973-5b530380-b963-11eb-921e-8b0af6a4c744.png)
