### PR TITLE
Remove invalid indexed field entry

### DIFF
--- a/lib/cards/contrib/support-thread.js
+++ b/lib/cards/contrib/support-thread.js
@@ -97,7 +97,7 @@ module.exports = ({
 				}
 			},
 			indexed_fields: [
-				[ 'data.status', 'data.category', 'data.product' ]
+				[ 'data.status', 'data.category' ]
 			]
 		}
 	})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Looks like we had an old `indexed_fields` entry hanging around, removing it as it references a non-existent child of `data`.