### PR TITLE
Don't mirror empty values to Outreach

### DIFF
--- a/lib/integrations/outreach.js
+++ b/lib/integrations/outreach.js
@@ -78,8 +78,10 @@ const getProspectAttributes = (contact) => {
 
 	for (const mapping of USER_PROSPECT_MAPPING) {
 		const value = _.get(contact, mapping.user)
-		const fn = mapping.fn || _.identity
-		_.set(attributes, mapping.prospect, fn(value))
+		if (value) {
+			const fn = mapping.fn || _.identity
+			_.set(attributes, mapping.prospect, fn(value))
+		}
 	}
 
 	return attributes


### PR DESCRIPTION
If the mapped value is falsey, don't mirror it to Outreach

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>