### PR TITLE
Allow external support users to read/write create and update events

### DIFF
--- a/lib/cards/contrib/role-user-external-support.json
+++ b/lib/cards/contrib/role-user-external-support.json
@@ -100,7 +100,9 @@
                 "card",
                 "link",
                 "message",
-                "support-thread"
+                "support-thread",
+                "create",
+                "update"
               ]
             },
             "type": {


### PR DESCRIPTION
This change has no user facing impact, but will allow us to transition
to a worker model that doesn't escalate privileges in the future.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>