### PR TITLE
Update node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/product-os/jellyfish-plugin-default.git"
   },
   "engines": {
-    "node": ">=14.2.0"
+    "node": ">=12.15.0"
   },
   "description": "Default Jellyfish Plugin",
   "main": "lib/index.js",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

`store-npm` CI step for consumers who do not have a `package-lock.json`.