### PR TITLE
Add peer dependencies for Jellyfish packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
     "sinon": "^11.1.1",
     "typed-errors": "^1.1.0"
   },
+  "peerDependencies": {
+    "@balena/jellyfish-action-library": "^13.0.0",
+    "@balena/jellyfish-core": "^3.0.0",
+    "@balena/jellyfish-sync": "^6.0.16"
+  },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   }


### PR DESCRIPTION
As we test against particular versions of these JF packages, it makes sense to specify them as peer dependencies as well so that anyone using this package is also encouraged/forced to use compatible versions of those peer dependencies.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>