### PR TITLE
Fix query for contact's support threads

### DIFF
--- a/lib/cards/contrib/contact.js
+++ b/lib/cards/contrib/contact.js
@@ -165,7 +165,7 @@ module.exports = ({
 										type: 'object',
 										properties: {
 											type: {
-												const: 'create'
+												const: 'create@1.0.0'
 											},
 											data: {
 												type: 'object',
@@ -189,7 +189,7 @@ module.exports = ({
 								type: 'object',
 								properties: {
 									type: {
-										const: 'support-thread'
+										const: 'support-thread@1.0.0'
 									}
 								}
 							}


### PR DESCRIPTION
Needed to add the version suffix to the type filters

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes: https://github.com/product-os/jellyfish/issues/6754

(I also did a search through our codebase to try and find any other places where we specify `const: '<type>'` instead of `const: '<type>@<version>'` but couldn't find any other places).