### PR TITLE
Update improvement status options

### DIFF
--- a/lib/cards/contrib/improvement.js
+++ b/lib/cards/contrib/improvement.js
@@ -10,10 +10,9 @@ const DEFAULT_CONTENT = fs.readFileSync(path.join(__dirname, 'improvement-defaul
 
 const statusOptions = [
 	'proposed',
-	'waiting',
 	'researching',
-	'candidate-spec',
-	'assigned-resources',
+	'awaiting-approval',
+	'ready-to-implement',
 	'implementation',
 	'all-milestones-completed',
 	'finalising-and-testing',
@@ -24,10 +23,9 @@ const statusOptions = [
 
 const statusNames = [
 	'Proposed',
-	'Waiting',
 	'Researching (Drafting Spec)',
-	'Candidate spec',
-	'Assigned resources',
+	'Awaiting approval',
+	'Ready to implement',
 	'Implementation',
 	'All milestones completed',
 	'Finalising and testing',


### PR DESCRIPTION
Although this is technically a breaking change, the status options will just be manually migrated as there are only 3 affected improvement contracts in production.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Migration tasks

waiting => (removed)
- _No contracts_

candidate-spec => awaiting-approval
- [SAML Integration For Balena Cloud Authentication](https://jel.ly.fish/product-improvement-saml-integration-for-balena-cloud-authentication-e2aaf3dc-ffab-4f3d-bb82-d167fa228e0c@1.0.0)

assigned-resources => ready-to-implement
- [Notifications in Jellyfish](https://jel.ly.fish/improvement-notifications-in-jellyfish-edd62665-3d71-4a8e-bdc6-1931144ed467@1.0.0)

