### PR TITLE
Make account name optional

### DIFF
--- a/lib/cards/contrib/account.js
+++ b/lib/cards/contrib/account.js
@@ -135,7 +135,6 @@ module.exports = ({
 					}
 				},
 				required: [
-					'name',
 					'data'
 				]
 			},

--- a/lib/integrations/balena-api.js
+++ b/lib/integrations/balena-api.js
@@ -140,7 +140,7 @@ const mergeUserKeys = (preExistingCard, card, payload, cardType) => {
 }
 
 const mergeOrgKeys = (preExistingCard, card, orgPayload, cardType) => {
-	const name = orgPayload.company || orgPayload.company_name
+	const name = orgPayload.company || orgPayload.company_name || orgPayload.name
 	const slug = getCardSlug(
 		cardType,
 		name


### PR DESCRIPTION
Occasionally, there isn't an account name available and we only have the
machine name. To improve data capture this change removes the
requirements for accounts to have names and also looks for the account
name in more locations when syncing balena webhooks.

Fixes https://github.com/product-os/jellyfish/issues/6545

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>