### PR TITLE
Fix external support role for notifications

### DIFF
--- a/lib/cards/contrib/role-user-external-support.json
+++ b/lib/cards/contrib/role-user-external-support.json
@@ -23,7 +23,31 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "link@1.0.0"
+              "enum": [
+                "link@1.0.0",
+                "subscription@1.0.0"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [ "type", "markers" ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "notification@1.0.0"
+            },
+            "markers": {
+              "type": "array",
+              "contains": {
+                "const": {
+                  "$eval": "user.slug"
+                }
+              },
+              "maxItems": 1,
+              "minItems": 1
             }
           }
         },
@@ -101,6 +125,8 @@
                 "link",
                 "message",
                 "support-thread",
+                "notification",
+                "subscription",
                 "create",
                 "update"
               ]
@@ -238,7 +264,6 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": [ "type", "slug" ],
           "properties": {
             "type": {


### PR DESCRIPTION
Change-type: patch

***

User with external support role can:

- Read notification and subscription types
- Read all subscriptions
- Read and write only his notifications

Also contains fix for failing notification query (see: https://jel.ly.fish/a288891c-ddb3-4771-af3a-42522a293e4d?event=3eda9acb-9ad0-45ba-a21b-90f9afbde042)