### PR TITLE
Update pattern status options

### DIFF
--- a/lib/cards/contrib/pattern.js
+++ b/lib/cards/contrib/pattern.js
@@ -4,10 +4,48 @@
  * Proprietary and confidential.
  */
 
+const statusOptions = [
+	'open',
+	'brainstorming',
+	'solution-agreed',
+	'partially-resolved',
+	'pending-validation',
+
+	// A pattern is resolved when the problem it describes has been verified as fixed
+	'closed-resolved',
+
+	// A pattern may be closed without resolution if it is no longer deemed relevant
+	// or, for whatever reason, cannot or will not be resolved.
+	'closed-unresolved',
+
+	// TODO: remove after migrating to closed-resolved/closed-unresolved
+	'closed',
+
+	// TODO: remove after migrating to closed-resolved/closed-unresolved
+	'archived'
+]
+
+const statusNames = [
+	'Open',
+	'Brainstorming',
+	'Solution agreed',
+	'Partially resolved',
+	'Pending validation',
+	'Closed - resolved',
+	'Closed - unresolved',
+
+	// TODO: remove these names when their corresponding statuses are removed
+	'Closed (deprecated)',
+	'Archived (deprecated)'
+]
+
 module.exports = ({
 	mixin, withEvents, asPipelineItem
 }) => {
-	return mixin(withEvents, asPipelineItem())({
+	return mixin(
+		withEvents,
+		asPipelineItem(statusOptions, statusOptions[0], statusNames)
+	)({
 		slug: 'pattern',
 		name: 'Pattern',
 		type: 'type@1.0.0',

--- a/lib/cards/contrib/triggered-action-support-closed-pattern-reopen.json
+++ b/lib/cards/contrib/triggered-action-support-closed-pattern-reopen.json
@@ -33,7 +33,7 @@
             }
           },
           "type": "object",
-          "required": [ "active", "type", "data" ],
+          "required": [ "active", "type" ],
           "properties": {
             "active": {
               "type": "boolean",
@@ -42,16 +42,6 @@
             "type": {
               "type": "string",
               "const": "pattern@1.0.0"
-            },
-            "data": {
-              "type": "object",
-              "required": [ "status" ],
-              "properties": {
-                "status": {
-                  "type": "string",
-                  "const": "closed"
-                }
-              }
             }
           }
         }
@@ -87,7 +77,7 @@
                   },
                   "value": {
                     "type": "string",
-                    "const": "closed"
+                    "const": "closed-resolved"
                   }
                 }
               }


### PR DESCRIPTION
We'll need to remove the deprecated status options once we have migrated any patterns from those statuses into their equivalent new statuses.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>