### PR TITLE
Use mixins in the opportunity contract

### DIFF
--- a/lib/cards/contrib/opportunity.ts
+++ b/lib/cards/contrib/opportunity.ts
@@ -7,8 +7,25 @@
 import type { Mixins } from '@balena/jellyfish-plugin-base';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-export function opportunity({ uiSchemaDef }: Mixins): ContractDefinition {
-	return {
+const statusOptions = [
+	'Created',
+	'Discovery',
+	'Evaluation',
+	'Committed ',
+	'Closed Won',
+	'Closed Lost',
+];
+
+export function opportunity({
+	mixin,
+	uiSchemaDef,
+	withEvents,
+	asPipelineItem,
+}: Mixins): ContractDefinition {
+	return mixin(
+		withEvents,
+		asPipelineItem(statusOptions, statusOptions[0]),
+	)({
 		slug: 'opportunity',
 		name: 'Opportunity',
 		type: 'type@1.0.0',
@@ -95,5 +112,5 @@ export function opportunity({ uiSchemaDef }: Mixins): ContractDefinition {
 			},
 			slices: ['properties.data.properties.status'],
 		},
-	};
+	});
 }


### PR DESCRIPTION
Main change is adding evaluated fields from the `withEvents` mixin. This should be added to almost every contract type really!

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***