### PR TITLE
Add pattern snapback triggered actions

### DIFF
--- a/lib/cards/contrib/triggered-action-pattern-all-improvements-completed.ts
+++ b/lib/cards/contrib/triggered-action-pattern-all-improvements-completed.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+
+export const triggeredActionPatternAllImprovementsCompleted: TriggeredActionContractDefinition =
+	{
+		slug: 'triggered-action-pattern-all-improvements-completed',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for updating pattern status when all improvements are completed',
+		markers: [],
+		data: {
+			schedule: 'sync',
+			filter: {
+				type: 'object',
+				required: ['active', 'type', 'data'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'pattern@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['status', 'improvementsPercentComplete'],
+						properties: {
+							status: {
+								type: 'string',
+								enum: ['improvement-in-progress', 'partially-resolved'],
+							},
+							improvementsPercentComplete: {
+								type: 'number',
+								const: 100,
+							},
+						},
+					},
+				},
+			},
+			action: 'action-update-card@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {
+				reason:
+					"Pattern status set to 'Resolved (pending review)' because all linked improvements are completed",
+				patch: [
+					{
+						op: 'replace',
+						path: '/data/status',
+						value: 'resolved-pending-review',
+					},
+				],
+			},
+		},
+	};

--- a/lib/cards/contrib/triggered-action-pattern-some-improvements-completed.ts
+++ b/lib/cards/contrib/triggered-action-pattern-some-improvements-completed.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+
+export const triggeredActionPatternSomeImprovementsCompleted: TriggeredActionContractDefinition =
+	{
+		slug: 'triggered-action-pattern-some-improvements-completed',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for updating pattern status when some - but not all - improvements are completed',
+		markers: [],
+		data: {
+			schedule: 'sync',
+			filter: {
+				type: 'object',
+				required: ['active', 'type', 'data'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'pattern@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['status', 'improvementsPercentComplete'],
+						properties: {
+							status: {
+								type: 'string',
+								enum: ['improvement-in-progress', 'resolved-pending-review'],
+							},
+							improvementsPercentComplete: {
+								type: 'number',
+								exclusiveMinimum: 0,
+								exclusiveMaximum: 100,
+							},
+						},
+					},
+				},
+			},
+			action: 'action-update-card@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {
+				reason:
+					"Pattern status set to 'Partially resolved' because some - but not all - linked improvements are completed",
+				patch: [
+					{
+						op: 'replace',
+						path: '/data/status',
+						value: 'partially-resolved',
+					},
+				],
+			},
+		},
+	};

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -52,6 +52,8 @@ import { triggeredActionHangoutsLink } from './contrib/triggered-action-hangouts
 import { triggeredActionIncrementTag } from './contrib/triggered-action-increment-tag';
 import { triggeredActionUserContact } from './contrib/triggered-action-user-contact';
 import { triggeredActionIntegrationImportEvent } from './contrib/triggered-action-integration-import-event';
+import { triggeredActionPatternAllImprovementsCompleted } from './contrib/triggered-action-pattern-all-improvements-completed';
+import { triggeredActionPatternSomeImprovementsCompleted } from './contrib/triggered-action-pattern-some-improvements-completed';
 import { triggeredActionSetUserAvatar } from './contrib/triggered-action-set-user-avatar';
 import { triggeredActionSupportSummary } from './contrib/triggered-action-support-summary';
 import { triggeredActionSupportReopen } from './contrib/triggered-action-support-reopen';
@@ -145,6 +147,8 @@ export const cards = [
 	triggeredActionIncrementTag,
 	triggeredActionUserContact,
 	triggeredActionIntegrationImportEvent,
+	triggeredActionPatternAllImprovementsCompleted,
+	triggeredActionPatternSomeImprovementsCompleted,
 	triggeredActionSetUserAvatar,
 	triggeredActionSupportSummary,
 	triggeredActionSupportReopen,


### PR DESCRIPTION
[Add triggered actions for auto-updating pattern status](https://github.com/product-os/jellyfish-plugin-default/commit/a28d7363060cdf349199ffb91ae8a976a3476b48)

When some but not all linked improvements are completed, pattern status is updated to 'partially-resolved'.

When all linked improvements are completed, pattern status is updated to 'resolved-pending-review'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Tested by: https://github.com/product-os/jellyfish/pull/6959