### PR TITLE
Add improvement snapback triggered action

### DIFF
--- a/lib/cards/contrib/triggered-action-improvement-all-milestones-completed.ts
+++ b/lib/cards/contrib/triggered-action-improvement-all-milestones-completed.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+
+export const triggeredActionImprovementAllMilestonesCompleted: TriggeredActionContractDefinition =
+	{
+		slug: 'triggered-action-improvement-all-milestones-completed',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for updating improvement status when all milestones are completed',
+		markers: [],
+		data: {
+			schedule: 'sync',
+			filter: {
+				type: 'object',
+				required: ['active', 'type', 'data'],
+				properties: {
+					active: {
+						type: 'boolean',
+						const: true,
+					},
+					type: {
+						type: 'string',
+						const: 'improvement@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['status', 'milestonesPercentComplete'],
+						properties: {
+							status: {
+								type: 'string',
+								not: {
+									enum: ['denied-or-failed', 'completed'],
+								},
+							},
+							milestonesPercentComplete: {
+								type: 'number',
+								const: 100,
+							},
+						},
+					},
+				},
+			},
+			action: 'action-update-card@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {
+				reason:
+					"Improvement status set to 'Completed' because all linked milestones are completed",
+				patch: [
+					{
+						op: 'replace',
+						path: '/data/status',
+						value: 'completed',
+					},
+				],
+			},
+		},
+	};

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -49,6 +49,7 @@ import { webPushSubscription } from './contrib/web-push-subscription';
 import { group } from './contrib/group';
 import { summary } from './contrib/summary';
 import { triggeredActionHangoutsLink } from './contrib/triggered-action-hangouts-link';
+import { triggeredActionImprovementAllMilestonesCompleted } from './contrib/triggered-action-improvement-all-milestones-completed';
 import { triggeredActionIncrementTag } from './contrib/triggered-action-increment-tag';
 import { triggeredActionUserContact } from './contrib/triggered-action-user-contact';
 import { triggeredActionIntegrationImportEvent } from './contrib/triggered-action-integration-import-event';
@@ -142,6 +143,7 @@ export const cards = [
 
 	// Triggered actions
 	triggeredActionHangoutsLink,
+	triggeredActionImprovementAllMilestonesCompleted,
 	triggeredActionIncrementTag,
 	triggeredActionUserContact,
 	triggeredActionIntegrationImportEvent,


### PR DESCRIPTION
[Add triggered action for auto-updating improvement status](https://github.com/product-os/jellyfish-plugin-default/commit/cbd8ae0a1729233abb244c97c3a339f6ceae3021)

When all linked milestones are completed, improvement status is updated to 'completed'.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Tested by: https://github.com/product-os/jellyfish/pull/6962
