### PR TITLE
brainstorm-topic reporter is not required

### DIFF
--- a/lib/cards/contrib/brainstorm-topic.ts
+++ b/lib/cards/contrib/brainstorm-topic.ts
@@ -34,7 +34,7 @@ export function brainstormTopic({
 					},
 					data: {
 						type: 'object',
-						required: ['reporter', 'category', 'description'],
+						required: ['category', 'description'],
 						properties: {
 							reporter: {
 								type: 'string',


### PR DESCRIPTION
This will make it easier to import legacy brainstorm topics from Front.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>