### PR TITLE
Bring back data.product for support threads

### DIFF
--- a/lib/cards/contrib/support-thread.ts
+++ b/lib/cards/contrib/support-thread.ts
@@ -76,6 +76,10 @@ export function supportThread({
 								type: 'string',
 								fullTextSearch: true,
 							},
+							product: {
+								title: 'Product',
+								type: 'string',
+							},
 						},
 					},
 				},
@@ -99,7 +103,7 @@ export function supportThread({
 					},
 				},
 			},
-			indexed_fields: [['data.status', 'data.category']],
+			indexed_fields: [['data.status', 'data.category', 'data.product']],
 		},
 	});
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Adding `data.product` back(?) to the `support-thread` contract type definition. We currently do use this field to differentiate between Jellyfish support threads and balenaCloud support threads for example. Not sure why it was removed or wasn't defined in the first place. At one point, I removed `data.product` from the list of fields used to create this type's `indexed_field`, but am adding that back as well. Will need to manually remove the current type index that doesn't reference `data.product` as our current deployment process doesn't automatically remove indexes like these.

Also checked that `data.product` wasn't around when we put together `plugin-default` ~7 months ago: https://github.com/product-os/jellyfish-plugin-default/blob/74a1cf2841d85bb9c0436ea54aec115c229b3c3a/lib/default-cards/contrib/support-thread.js