### PR TITLE
Use mixins in workflow contract definition

### DIFF
--- a/lib/cards/contrib/workflow.ts
+++ b/lib/cards/contrib/workflow.ts
@@ -4,101 +4,84 @@
  * Proprietary and confidential.
  */
 
+import type { Mixins } from '@balena/jellyfish-plugin-base';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-export const workflow: ContractDefinition = {
-	slug: 'workflow',
-	type: 'type@1.0.0',
-	name: 'Workflow',
-	markers: [],
-	data: {
-		schema: {
-			type: 'object',
-			properties: {
-				name: {
-					type: ['string', 'null'],
-					fullTextSearch: true,
-				},
-				tags: {
-					type: 'array',
-					items: {
-						type: 'string',
+const statusOptions = ['draft', 'candidate', 'complete'];
+
+const statusNames = ['Draft', 'Candidate', 'Complete'];
+
+export function workflow({
+	mixin,
+	withEvents,
+	asPipelineItem,
+}: Mixins): ContractDefinition {
+	return mixin(
+		withEvents,
+		asPipelineItem(statusOptions, statusOptions[0], statusNames),
+	)({
+		slug: 'workflow',
+		type: 'type@1.0.0',
+		name: 'Workflow',
+		data: {
+			schema: {
+				type: 'object',
+				properties: {
+					name: {
+						type: ['string', 'null'],
+						fullTextSearch: true,
 					},
-					$$formula: "AGGREGATE($events, 'tags')",
-				},
-				data: {
-					type: 'object',
-					properties: {
-						status: {
-							title: 'Status',
-							type: 'string',
-							default: 'draft',
-							enum: ['draft', 'candidate', 'complete'],
-						},
-						loop: {
-							type: 'string',
-						},
-						lifecycle: {
-							type: 'string',
-						},
-						description: {
-							type: 'string',
-							format: 'markdown',
-						},
-						diagram: {
-							type: 'string',
-							format: 'mermaid',
+					data: {
+						type: 'object',
+						properties: {
+							lifecycle: {
+								type: 'string',
+							},
+							description: {
+								type: 'string',
+								format: 'markdown',
+							},
+							diagram: {
+								type: 'string',
+								format: 'mermaid',
+							},
 						},
 					},
 				},
 			},
-		},
-		uiSchema: {
-			fields: {
-				'ui:options': {
-					alignSelf: 'stretch',
-				},
-				data: {
+			uiSchema: {
+				fields: {
 					'ui:options': {
 						alignSelf: 'stretch',
 					},
-					status: {
-						'ui:widget': 'Badge',
-					},
-					diagram: {
-						'ui:options': {
-							alignSelf: 'stretch',
+					data: {
+						diagram: {
+							'ui:options': {
+								alignSelf: 'stretch',
+							},
 						},
 					},
 				},
-			},
-			edit: {
-				$ref: '#/data/uiSchema/definitions/form',
-			},
-			create: {
-				$ref: '#/data/uiSchema/edit',
-			},
-			definitions: {
-				form: {
-					data: {
-						loop: {
-							'ui:widget': 'AutoCompleteWidget',
-							'ui:options': {
-								resource: 'workflow',
-								keyPath: 'data.loop',
-							},
-						},
-						lifecycle: {
-							'ui:widget': 'AutoCompleteWidget',
-							'ui:options': {
-								resource: 'workflow',
-								keyPath: 'data.lifecycle',
+				edit: {
+					$ref: '#/data/uiSchema/definitions/form',
+				},
+				create: {
+					$ref: '#/data/uiSchema/edit',
+				},
+				definitions: {
+					form: {
+						data: {
+							lifecycle: {
+								'ui:widget': 'AutoCompleteWidget',
+								'ui:options': {
+									resource: 'workflow',
+									keyPath: 'data.lifecycle',
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-		slices: ['properties.data.properties.status'],
-	},
-};
+	});
+}


### PR DESCRIPTION
Remove redundant data.loop field (all values have already been migrated to the top-level loop field).

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>