### PR TITLE
Assign support thread views to loops

### DIFF
--- a/lib/cards/balena/view-all-forum-threads.ts
+++ b/lib/cards/balena/view-all-forum-threads.ts
@@ -11,6 +11,7 @@ export const viewAllForumThreads: ViewContractDefinition = {
 	name: 'Forums',
 	type: 'view@1.0.0',
 	markers: ['org-balena'],
+	loop: 'loop-balena-io@1.0.0',
 	data: {
 		namespace: 'Support',
 		allOf: [

--- a/lib/cards/balena/view-all-jellyfish-support-threads.ts
+++ b/lib/cards/balena/view-all-jellyfish-support-threads.ts
@@ -11,6 +11,7 @@ export const viewAllJellyfishSupportThreads: ViewContractDefinition = {
 	name: 'Jellyfish threads',
 	type: 'view@1.0.0',
 	markers: ['org-balena'],
+	loop: 'loop-product-os@1.0.0',
 	data: {
 		namespace: 'Support',
 		allOf: [

--- a/lib/cards/balena/view-customer-success-support-threads.ts
+++ b/lib/cards/balena/view-customer-success-support-threads.ts
@@ -11,6 +11,7 @@ export const viewCustomerSuccessSupportThreads: ViewContractDefinition = {
 	name: 'Customer success',
 	type: 'view@1.0.0',
 	markers: ['org-balena'],
+	loop: 'loop-balena-io@1.0.0',
 	data: {
 		namespace: 'Support',
 		allOf: [

--- a/lib/cards/balena/view-paid-support-threads.ts
+++ b/lib/cards/balena/view-paid-support-threads.ts
@@ -11,6 +11,7 @@ export const viewPaidSupportThreads: ViewContractDefinition = {
 	name: 'Paid support',
 	type: 'view@1.0.0',
 	markers: ['org-balena'],
+	loop: 'loop-balena-io@1.0.0',
 	data: {
 		namespace: 'Support',
 		allOf: [

--- a/lib/cards/balena/view-security-support-threads.ts
+++ b/lib/cards/balena/view-security-support-threads.ts
@@ -11,6 +11,7 @@ export const viewSecuritySupportThreads: ViewContractDefinition = {
 	name: 'Security',
 	type: 'view@1.0.0',
 	markers: ['org-balena'],
+	loop: 'loop-balena-io@1.0.0',
 	data: {
 		namespace: 'Support',
 		allOf: [


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This is a somewhat temporary measure as we know we want to refactor how support thread views are materialized and organized. But for now, this will mean that when you select a global loop filter, you won't see views that are not relevant to that loop.