### PR TITLE
Update evaluated fields to reference 'contract' instead of 'this'

### DIFF
--- a/lib/cards/contrib/account.ts
+++ b/lib/cards/contrib/account.ts
@@ -122,7 +122,7 @@ export function account({ uiSchemaDef }: Mixins): ContractDefinition {
 									'Calculated with the formula: monthlyPrice * (1 - discountPercentage). This number is excluding plan addons',
 								type: 'number',
 								$$formula:
-									'SUM(this.data.monthlyPrice * (1-this.data.discountPercentage))',
+									'SUM(contract.data.monthlyPrice * (1 - contract.data.discountPercentage))',
 								readOnly: true,
 							},
 							SumAnnualPrice: {
@@ -131,7 +131,7 @@ export function account({ uiSchemaDef }: Mixins): ContractDefinition {
 									'Calculated with the formula: annualPrice * (1 - discountPercentage). This number is excluding plan addons',
 								type: 'number',
 								$$formula:
-									'SUM(this.data.annualPrice * (1 - this.data.discountPercentage))',
+									'SUM(contract.data.annualPrice * (1 - contract.data.discountPercentage))',
 								readOnly: true,
 							},
 						},

--- a/lib/cards/contrib/improvement.ts
+++ b/lib/cards/contrib/improvement.ts
@@ -75,7 +75,7 @@ export function improvement({
 								readOnly: true,
 								// eslint-disable-next-line max-len
 								$$formula:
-									'this.links["has attached"] && this.links["has attached"].length ? (FILTER(this.links["has attached"], { type: "milestone@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(this.links["has attached"], { type: "milestone@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
+									'contract.links["has attached"] && contract.links["has attached"].length ? (FILTER(contract.links["has attached"], { type: "milestone@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(contract.links["has attached"], { type: "milestone@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
 							},
 						},
 					},

--- a/lib/cards/contrib/opportunity.ts
+++ b/lib/cards/contrib/opportunity.ts
@@ -76,7 +76,7 @@ export function opportunity({
 								type: 'number',
 								format: 'currency',
 								$$formula:
-									'SUM([this.data.recurringValue, this.data.nonRecurringValue])',
+									'SUM([contract.data.recurringValue, contract.data.nonRecurringValue])',
 								minimum: 0,
 							},
 							device: {

--- a/lib/cards/contrib/pattern.ts
+++ b/lib/cards/contrib/pattern.ts
@@ -67,7 +67,7 @@ export function pattern({
 								readOnly: true,
 								// eslint-disable-next-line max-len
 								$$formula:
-									'this.links["has attached"] && this.links["has attached"].length ? (FILTER(this.links["has attached"], { type: "improvement@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(this.links["has attached"], { type: "improvement@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
+									'contract.links["has attached"] && contract.links["has attached"].length ? (FILTER(contract.links["has attached"], { type: "improvement@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(contract.links["has attached"], { type: "improvement@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
 							},
 						},
 					},

--- a/lib/cards/contrib/rating.ts
+++ b/lib/cards/contrib/rating.ts
@@ -69,9 +69,9 @@ export function rating({ uiSchemaDef }: Mixins): ContractDefinition {
 										type: 'string',
 										$$formula:
 											// eslint-disable-next-line max-len
-											'(this.data.payload.score ? "Review score: " + this.data.payload.score + "/5" : "") +' +
+											'(contract.data.payload.score ? "Review score: " + contract.data.payload.score + "/5" : "") +' +
 											// eslint-disable-next-line max-len
-											'(this.data.payload.comment ? "\\n\\nReview comment:\\n" + this.data.payload.comment : "")',
+											'(contract.data.payload.comment ? "\\n\\nReview comment:\\n" + contract.data.payload.comment : "")',
 										readOnly: true,
 									},
 									comment: {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@balena/jellyfish-config": "^1.4.4",
     "@balena/jellyfish-core": "^5.0.1",
     "@balena/jellyfish-sync": "^6.0.287",
-    "@balena/jellyfish-test-harness": "^6.0.5",
+    "@balena/jellyfish-test-harness": "^6.0.45",
     "@balena/jellyfish-types": "^0.8.6",
     "@balena/lint": "^6.1.1",
     "@types/is-uuid": "^1.0.0",


### PR DESCRIPTION
Update jellyfish-test-harness dev dependency - pulls in latest jellyscript.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>