### PR TITLE
Add data.actor indexes

### DIFF
--- a/lib/cards/contrib/message.ts
+++ b/lib/cards/contrib/message.ts
@@ -176,6 +176,7 @@ export function message({ uiSchemaDef }: Mixins): ContractDefinition {
 				['data.payload.alertsUser'],
 				['data.payload.mentionsGroup'],
 				['data.payload.alertsGroup'],
+				['data.actor'],
 			],
 		},
 	};

--- a/lib/cards/contrib/rating.ts
+++ b/lib/cards/contrib/rating.ts
@@ -171,6 +171,7 @@ export function rating({ uiSchemaDef }: Mixins): ContractDefinition {
 				['data.payload.alertsUser'],
 				['data.payload.mentionsGroup'],
 				['data.payload.alertsGroup'],
+				['data.actor'],
 			],
 		},
 	};

--- a/lib/cards/contrib/summary.ts
+++ b/lib/cards/contrib/summary.ts
@@ -85,6 +85,7 @@ export const summary: ContractDefinition = {
 			['data.payload.alertsUser'],
 			['data.payload.mentionsGroup'],
 			['data.payload.alertsGroup'],
+			['data.actor'],
 		],
 	},
 };

--- a/lib/cards/contrib/whisper.ts
+++ b/lib/cards/contrib/whisper.ts
@@ -152,6 +152,7 @@ export function whisper({ uiSchemaDef }: Mixins): ContractDefinition {
 				['data.payload.alertsUser'],
 				['data.payload.mentionsGroup'],
 				['data.payload.alertsGroup'],
+				['data.actor'],
 			],
 		},
 	};


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add partial indexes for `data.actor` on a few card types, *should* help speed up inbox load query execution times.

Depends on:
- https://github.com/product-os/jellyfish-core/pull/866