### PR TITLE
Mark loop field as required on several contract types

### DIFF
--- a/lib/cards/contrib/brainstorm-call.ts
+++ b/lib/cards/contrib/brainstorm-call.ts
@@ -20,10 +20,14 @@ export function brainstormCall({
 		data: {
 			schema: {
 				type: 'object',
+				required: ['name', 'loop', 'data'],
 				properties: {
 					name: {
 						type: 'string',
 						fullTextSearch: true,
+					},
+					loop: {
+						type: 'string',
 					},
 					data: {
 						type: 'object',

--- a/lib/cards/contrib/brainstorm-topic.ts
+++ b/lib/cards/contrib/brainstorm-topic.ts
@@ -26,11 +26,14 @@ export function brainstormTopic({
 		data: {
 			schema: {
 				type: 'object',
-				required: ['name', 'data'],
+				required: ['name', 'loop', 'data'],
 				properties: {
 					name: {
 						type: 'string',
 						fullTextSearch: true,
+					},
+					loop: {
+						type: 'string',
 					},
 					data: {
 						type: 'object',

--- a/lib/cards/contrib/improvement.ts
+++ b/lib/cards/contrib/improvement.ts
@@ -56,6 +56,9 @@ export function improvement({
 						pattern: '^.*\\S.*$',
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -80,7 +83,7 @@ export function improvement({
 						},
 					},
 				},
-				required: ['name', 'data'],
+				required: ['name', 'loop', 'data'],
 			},
 			uiSchema: {
 				fields: {

--- a/lib/cards/contrib/milestone.ts
+++ b/lib/cards/contrib/milestone.ts
@@ -32,8 +32,11 @@ export function milestone({
 						type: 'string',
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 				},
-				required: ['name'],
+				required: ['name', 'loop'],
 			},
 			uiSchema: {
 				snippet: {

--- a/lib/cards/contrib/pattern.ts
+++ b/lib/cards/contrib/pattern.ts
@@ -52,6 +52,9 @@ export function pattern({
 						type: 'string',
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -72,7 +75,7 @@ export function pattern({
 						},
 					},
 				},
-				required: ['name'],
+				required: ['name', 'loop'],
 			},
 			uiSchema: {
 				fields: {

--- a/lib/cards/contrib/project.ts
+++ b/lib/cards/contrib/project.ts
@@ -40,12 +40,15 @@ export function project({
 		data: {
 			schema: {
 				type: 'object',
-				required: ['name'],
+				required: ['name', 'loop'],
 				properties: {
 					name: {
 						type: 'string',
 						pattern: '^.*\\S.*$',
 						fullTextSearch: true,
+					},
+					loop: {
+						type: 'string',
 					},
 					data: {
 						type: 'object',

--- a/lib/cards/contrib/saga.ts
+++ b/lib/cards/contrib/saga.ts
@@ -28,6 +28,9 @@ export function saga({
 						pattern: '^.*\\S.*$',
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -39,7 +42,7 @@ export function saga({
 						required: ['description'],
 					},
 				},
-				required: ['name', 'data'],
+				required: ['name', 'loop', 'data'],
 			},
 			uiSchema: {
 				fields: {

--- a/lib/cards/contrib/support-thread.ts
+++ b/lib/cards/contrib/support-thread.ts
@@ -28,6 +28,9 @@ export function supportThread({
 						type: ['string', 'null'],
 						fullTextSearch: true,
 					},
+					loop: {
+						type: 'string',
+					},
 					data: {
 						type: 'object',
 						properties: {
@@ -99,7 +102,7 @@ export function supportThread({
 						},
 					},
 				},
-				required: ['data'],
+				required: ['loop', 'data'],
 			},
 			uiSchema: {
 				fields: {

--- a/lib/cards/contrib/workflow.ts
+++ b/lib/cards/contrib/workflow.ts
@@ -26,10 +26,14 @@ export function workflow({
 		data: {
 			schema: {
 				type: 'object',
+				required: ['name', 'loop'],
 				properties: {
 					name: {
 						type: ['string', 'null'],
 						fullTextSearch: true,
+					},
+					loop: {
+						type: 'string',
 					},
 					data: {
 						type: 'object',


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This PR makes the `loop` field required on the following contract types:
* `brainstorm-topic`
* `brainstorm-call`
* `milestone`
* `project`
* `improvement`
* `pattern`
* `saga`
* `workflow`
* `support-thread`