### PR TITLE
Fetch bookmark links with views in view-all-views

### DIFF
--- a/lib/cards/contrib/view-all-views.ts
+++ b/lib/cards/contrib/view-all-views.ts
@@ -17,6 +17,27 @@ export const viewAllViews: ViewContractDefinition = {
 				name: 'Card type view',
 				schema: {
 					type: 'object',
+					anyOf: [
+						{
+							$$links: {
+								'is bookmarked by': {
+									type: 'object',
+									required: ['type', 'id'],
+									properties: {
+										type: {
+											const: 'user@1.0.0',
+										},
+										id: {
+											const: {
+												$eval: 'user.id',
+											},
+										},
+									},
+								},
+							},
+						},
+						true,
+					],
 					properties: {
 						type: {
 							type: 'string',


### PR DESCRIPTION
This ensures we know if a view is bookmarked by the current user without having to execute a secondary query.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to https://github.com/product-os/jellyfish-client-sdk/pull/474