### PR TITLE
Add data.schedule to brainstorm calls

### DIFF
--- a/lib/cards/contrib/brainstorm-call.ts
+++ b/lib/cards/contrib/brainstorm-call.ts
@@ -33,6 +33,26 @@ export function brainstormCall({
 								type: 'string',
 								format: 'date-time',
 							},
+							schedule: {
+								title: 'Meeting schedule',
+								type: 'object',
+								properties: {
+									start: {
+										title: 'Start date/time',
+										type: 'string',
+										format: 'date-time',
+									},
+									end: {
+										title: 'End date/time',
+										type: 'string',
+										format: 'date-time',
+									},
+									interval: {
+										title: 'Interval',
+										type: 'string',
+									},
+								},
+							},
 						},
 						required: ['datetime'],
 					},


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add optional `data.schedule` to `brainstorm-call` contracts for scheduled actions. Just testing ideas out at the moment.