### PR TITLE
Modify view-all-views to exclude custom views created by other users

### DIFF
--- a/lib/cards/contrib/view-all-views.ts
+++ b/lib/cards/contrib/view-all-views.ts
@@ -47,9 +47,22 @@ export const viewAllViews: ViewContractDefinition = {
 							type: 'boolean',
 							const: true,
 						},
+						data: {
+							type: 'object',
+							properties: {
+								actor: {
+									type: 'string',
+									description:
+										'The actor field is not required, but if it is present it should only match the ID of the current user',
+									const: {
+										$eval: 'user.id',
+									},
+								},
+							},
+						},
 					},
 					additionalProperties: true,
-					required: ['type'],
+					required: ['type', 'data'],
 				},
 			},
 		],


### PR DESCRIPTION
This change modifies the "All views" view to exclude any custom views
created by other users. This is indicated by the presence of an `actor`
field on the view contract.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>