### PR TITLE
Move improvement TLDR to description

### DIFF
--- a/lib/cards/contrib/improvement-default.md
+++ b/lib/cards/contrib/improvement-default.md
@@ -1,7 +1,3 @@
-## TL;DR
-
-> *A quick summary of the proposed change or addition, who it affects and what it will enable them to do. This summary should be easy to just copy and paste into release notes, product release announces or team PSAs when the project ships.*
-
 ## Intro
 
 

--- a/lib/cards/contrib/improvement.ts
+++ b/lib/cards/contrib/improvement.ts
@@ -62,6 +62,7 @@ export function improvement({
 							description: {
 								type: 'string',
 								format: 'markdown',
+								title: 'TLDR',
 							},
 							specification: {
 								type: 'string',
@@ -88,8 +89,8 @@ export function improvement({
 						'ui:order': [
 							'status',
 							'milestonesPercentComplete',
-							'specification',
 							'description',
+							'specification',
 						],
 						milestonesPercentComplete: {
 							'ui:widget': 'ProgressBar',


### PR DESCRIPTION
Change-type: minor

***

Rename `description` field to `TLDR` and use it instead of TLDR section inside specification:

![tmp](https://user-images.githubusercontent.com/2152815/132356267-8883b90b-2f5d-4f78-921e-1d64750114d3.png)
