### PR TITLE
Add a simple weight formula to patterns

### DIFF
--- a/lib/cards/contrib/pattern.ts
+++ b/lib/cards/contrib/pattern.ts
@@ -77,6 +77,13 @@ export function pattern({
 								$$formula:
 									'contract.links["has attached"] && contract.links["has attached"].length ? (FILTER(contract.links["has attached"], { type: "improvement@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(contract.links["has attached"], { type: "improvement@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
 							},
+							weight: {
+								description: 'How active the pattern is',
+								default: 0,
+								type: 'number',
+								$$formula:
+									'contract.links["has attached"].length + contract.links["is attached to"].length + contract.links["relates to"].length',
+							},
 						},
 					},
 				},


### PR DESCRIPTION
This is a simple way to represent how many contracts a pattern is linked
to. Long term I'd like to introduce a time element here, so that the
weight decays over time.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>