### PR TITLE
Sync tags between user and contact

### DIFF
--- a/lib/actions/action-maintain-contact.ts
+++ b/lib/actions/action-maintain-contact.ts
@@ -54,6 +54,10 @@ const handler: ActionFile['handler'] = async (
 			value: card.name,
 		},
 		{
+			path: ['tags'],
+			value: card.tags,
+		},
+		{
 			path: ['data', 'origin'],
 			value: card.data.origin,
 		},


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Sync user root `/tags` field to contact `/tags` field