### PR TITLE
Merge contact tags instead of replace

### DIFF
--- a/lib/actions/action-maintain-contact.ts
+++ b/lib/actions/action-maintain-contact.ts
@@ -149,10 +149,15 @@ const handler: ActionFile['handler'] = async (
 		const patch = contactProperties.reduce(
 			(accumulator: any[], property: any) => {
 				const current = _.get(attachedContact, property.path);
-				const value =
+				let value =
 					_.isNil(property.value) || _.isEqual(property.value, {})
 						? current
 						: property.value;
+
+				// Merge and de-duplicate arrays
+				if (_.isArray(value) && !_.isEmpty(value)) {
+					value = _.union(current, value);
+				}
 
 				if (!_.isNil(value) && !_.isEqual(value, current)) {
 					accumulator.push({


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Instead of overwriting tags when syncing users with contacts, merge and de-duplicate them. Without this logic, we would override the tag on the contact that indicates the origin of the user (`balena-api` etc). What should really probably happen is this origin tag be added to the user contract when it is created and then that synced to the corresponding contact.