### PR TITLE
Sync contact tags with user, add tests

### DIFF
--- a/lib/actions/action-maintain-contact.ts
+++ b/lib/actions/action-maintain-contact.ts
@@ -149,15 +149,10 @@ const handler: ActionFile['handler'] = async (
 		const patch = contactProperties.reduce(
 			(accumulator: any[], property: any) => {
 				const current = _.get(attachedContact, property.path);
-				let value =
+				const value =
 					_.isNil(property.value) || _.isEqual(property.value, {})
 						? current
 						: property.value;
-
-				// Merge and de-duplicate arrays
-				if (_.isArray(value) && !_.isEmpty(value)) {
-					value = _.union(current, value);
-				}
 
 				if (!_.isNil(value) && !_.isEqual(value, current)) {
 					accumulator.push({


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove the array (aka tags) array `_.union()` logic added in earlier today. Thought this was a good idea at first, but it just adds confusion. This PR reverts that change restoring the previous logic of overwriting contact array values instead of merging them. This PR also adds a few tests to ensure the maintain contact action works as expected when adding/removing tags to/from a user.