### PR TITLE
Use correct typed error package

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "rimraf": "^3.0.2",
     "simple-git-hooks": "^2.7.0",
     "ts-jest": "^27.1.2",
-    "typed-errors": "^1.1.0",
+    "typed-error": "^3.2.1",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.4"
   },

--- a/test/integration/broken-integration.ts
+++ b/test/integration/broken-integration.ts
@@ -1,9 +1,9 @@
-import * as typedErrors from 'typed-errors';
+import { TypedError } from 'typed-error';
 
 // tslint:disable-next-line: no-var-requires
 const NoOpIntegration = require('./noop-integration');
 
-const TranslateError = typedErrors.makeTypedError('TranslateError');
+class TranslateError extends TypedError {}
 
 module.exports = class BrokenIntegration extends NoOpIntegration {
 	constructor(options: any) {


### PR DESCRIPTION
The decprecated `typed-errors` package was used by mistake instead of
the `typed-error` package.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>