### PR TITLE
Add a triggered-action to snapback from improvements to support threads

### DIFF
--- a/lib/cards/contrib/improvement.ts
+++ b/lib/cards/contrib/improvement.ts
@@ -1,8 +1,8 @@
 import type { Mixins } from '@balena/jellyfish-plugin-base';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const DEFAULT_CONTENT = fs.readFileSync(
 	path.join(__dirname, 'improvement-default.md'),

--- a/lib/cards/contrib/triggered-action-support-completed-improvement-reopen.ts
+++ b/lib/cards/contrib/triggered-action-support-completed-improvement-reopen.ts
@@ -1,13 +1,14 @@
 import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
 
-export const triggeredActionSupportClosedPatternReopen: TriggeredActionContractDefinition =
+const IMPROVEMENT_COMPLETE_STATUS = 'completed';
+
+export const triggeredActionSupportCompletedImprovementReopen: TriggeredActionContractDefinition =
 	{
-		slug: 'triggered-action-support-closed-pattern-reopen',
+		slug: 'triggered-action-support-completed-improvement-reopen',
 		type: 'triggered-action@1.0.0',
-		name: 'Triggered action for reopening support threads when patterns are closed',
+		name: 'Triggered action for reopening support threads when improvements are completed',
 		markers: [],
 		data: {
-			schedule: 'sync',
 			filter: {
 				$$links: {
 					'is attached to': {
@@ -58,32 +59,15 @@ export const triggeredActionSupportClosedPatternReopen: TriggeredActionContractD
 					},
 					type: {
 						type: 'string',
-						const: 'update@1.0.0',
+						const: 'improvement@1.0.0',
 					},
 					data: {
 						type: 'object',
-						required: ['payload'],
+						required: ['status'],
 						properties: {
-							payload: {
-								type: 'array',
-								contains: {
-									type: 'object',
-									required: ['op', 'path', 'value'],
-									properties: {
-										op: {
-											type: 'string',
-											const: 'replace',
-										},
-										path: {
-											type: 'string',
-											const: '/data/status',
-										},
-										value: {
-											type: 'string',
-											const: 'closed-resolved',
-										},
-									},
-								},
+							status: {
+								type: 'string',
+								const: IMPROVEMENT_COMPLETE_STATUS,
 							},
 						},
 					},
@@ -100,7 +84,8 @@ export const triggeredActionSupportClosedPatternReopen: TriggeredActionContractD
 				},
 			},
 			arguments: {
-				reason: 'Support Thread re-opened because linked Pattern was closed',
+				reason:
+					'Support Thread re-opened because linked Pattern was potentially resolved',
 				patch: [
 					{
 						op: 'replace',

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -48,7 +48,7 @@ import { triggeredActionIntegrationImportEvent } from './contrib/triggered-actio
 import { triggeredActionSetUserAvatar } from './contrib/triggered-action-set-user-avatar';
 import { triggeredActionSupportSummary } from './contrib/triggered-action-support-summary';
 import { triggeredActionSupportReopen } from './contrib/triggered-action-support-reopen';
-import { triggeredActionSupportClosedPatternReopen } from './contrib/triggered-action-support-closed-pattern-reopen';
+import { triggeredActionSupportCompletedImprovementReopen } from './contrib/triggered-action-support-completed-improvement-reopen';
 import { triggeredActionSyncThreadPostLinkWhisper } from './contrib/triggered-action-sync-thread-post-link-whisper';
 import { triggeredActionUpdateEventEditedAt } from './contrib/triggered-action-update-event-edited-at';
 import { viewAllViews } from './contrib/view-all-views';
@@ -138,7 +138,7 @@ export const cards = [
 	triggeredActionSetUserAvatar,
 	triggeredActionSupportSummary,
 	triggeredActionSupportReopen,
-	triggeredActionSupportClosedPatternReopen,
+	triggeredActionSupportCompletedImprovementReopen,
 	triggeredActionSyncThreadPostLinkWhisper,
 	triggeredActionUpdateEventEditedAt,
 


### PR DESCRIPTION
When a improvement is completed, iterate through the patterns attached
to it and re-open any support threads attached to those patterns.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>