### PR TITLE
Decay pattern weight over time

### DIFF
--- a/lib/cards/contrib/pattern.ts
+++ b/lib/cards/contrib/pattern.ts
@@ -1,6 +1,8 @@
 import type { Mixins } from '@balena/jellyfish-plugin-base';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
+const WEIGHT_GRAVITY = 1.8;
+
 const statusOptions = [
 	'open',
 	'brainstorming',
@@ -72,11 +74,17 @@ export function pattern({
 									'contract.links["has attached"] && contract.links["has attached"].length ? (FILTER(contract.links["has attached"], { type: "improvement@1.0.0", data: { status: "completed" } }).length / REJECT(FILTER(contract.links["has attached"], { type: "improvement@1.0.0" }), { data: { status: "denied-or-failed" } }).length) * 100 : 0',
 							},
 							weight: {
-								description: 'How active the pattern is',
+								description:
+									'How active the pattern is. Decays over time using the hackernews algorithm (Score = (P-1) / (T+2)^G)',
 								default: 0,
 								type: 'number',
-								$$formula:
-									'contract.links["has attached"].length + contract.links["is attached to"].length + contract.links["relates to"].length',
+								$$formula: `
+									(
+										contract.links["has attached"].length + 
+										contract.links["is attached to"].length + 
+										contract.links["relates to"].length
+									) / POWER((NOW() - DATEVALUE(contract.created_at)) / (1000 * 60 * 60), ${WEIGHT_GRAVITY})
+								`,
 							},
 						},
 					},


### PR DESCRIPTION
This change uses the same decay algorithm as Hackernews:
```
Score = (P) / (T+2)^G

where,
P = points of an item (number of times contract is linked to)
T = time since creation (in hours)
G = Gravity, defaults to 1.8 in news.arc
```

This is re-calculated whenever the pattern is updated, essentially
a "poor mans cron". Once scheduled actions are implemented, we should be
able to recalculate the weight at explicit intervals.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>