### PR TITLE
Remove dev-only peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,6 @@
     "typedoc": "^0.22.10",
     "typescript": "^4.5.4"
   },
-  "peerDependencies": {
-    "@balena/jellyfish-action-library": "^15.1.186",
-    "@balena/jellyfish-core": "^8.2.0",
-    "@balena/jellyfish-plugin-product-os": "^2.9.4",
-    "@balena/jellyfish-sync": "^6.1.129"
-  },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },


### PR DESCRIPTION
These only force dependencies to use the same version we're using during testing, which is not the same version they would use in production. Meaning we are testing against a different setup than prod.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>