### PR TITLE
Drop dependency on the jellyfish-mail package

### DIFF
--- a/lib/actions/action-request-password-reset.ts
+++ b/lib/actions/action-request-password-reset.ts
@@ -10,8 +10,9 @@ import type {
 	WorkerContext,
 } from '@balena/jellyfish-worker';
 import crypto from 'crypto';
-import { actionSendEmail, buildSendEmailOptions } from './action-send-email';
+import { actionSendEmail } from './action-send-email';
 import { PASSWORDLESS_USER_HASH } from './constants';
+import { buildSendEmailOptions } from './mail-utils';
 import { addLinkCard } from './utils';
 
 const logger = getLogger(__filename);

--- a/lib/actions/action-send-email.ts
+++ b/lib/actions/action-send-email.ts
@@ -1,11 +1,77 @@
 import { defaultEnvironment } from '@balena/jellyfish-environment';
-import mail, { SendEmailOptions } from '@balena/jellyfish-mail';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import type { ActionDefinition } from '@balena/jellyfish-worker';
+import { MailOptions } from '@balena/jellyfish-environment';
+import axios from 'axios';
+import FormData from 'form-data';
 
 const MAIL_OPTIONS = defaultEnvironment.mail.options || {
 	domain: '',
 };
+
+interface SendEmailOptions {
+	toAddress: string;
+	fromAddress: string;
+	subject: string;
+	html: string;
+}
+
+class Mailgun {
+	public options: MailOptions;
+	public domain: string;
+	public requestDomain: string;
+	public auth: {
+		user: string;
+		pass: string;
+	};
+
+	constructor(options: MailOptions) {
+		this.options = options;
+		this.domain = options.domain;
+		this.requestDomain = `${this.options.baseUrl}/${this.domain}`;
+		this.auth = {
+			user: 'api',
+			pass: this.options.token,
+		};
+	}
+
+	/**
+	 * @summary Send email using Mailgun api
+	 * @function
+	 *
+	 * @param options - send email options
+	 * @returns API request result
+	 *
+	 * @example
+	 * ```typescript
+	 * const result = await sendEmail({
+	 *   toAddress: 'user@domain.com',
+	 *   fromAddress: 'us@domain.com',
+	 *   subject: 'Hello',
+	 *   html: '<b>Hello</b>',
+	 * });
+	 * ```
+	 */
+	public async sendEmail(options: SendEmailOptions): Promise<any> {
+		const from = options.fromAddress
+			? options.fromAddress
+			: `Jel.ly.fish <no-reply@${this.domain}>`;
+
+		const form = new FormData();
+		form.append('from', from);
+		form.append('to', options.toAddress);
+		form.append('subject', options.subject);
+		form.append('html', options.html);
+
+		return await axios.post(`${this.requestDomain}/messages`, form, {
+			auth: {
+				username: this.auth.user,
+				password: this.auth.pass,
+			},
+			headers: form.getHeaders(),
+		});
+	}
+}
 
 /**
  * @summary Build and return send email request options.
@@ -42,8 +108,12 @@ const handler: ActionDefinition['handler'] = async (
 ) => {
 	const { fromAddress, toAddress, subject, html } = request.arguments;
 
-	if (mail) {
-		const response = await mail.sendEmail({
+	if (
+		defaultEnvironment.mail.type === 'mailgun' &&
+		defaultEnvironment.mail.options
+	) {
+		const client = new Mailgun(defaultEnvironment.mail.options);
+		const response = await client.sendEmail({
 			toAddress,
 			fromAddress,
 			subject,

--- a/lib/actions/action-send-email.ts
+++ b/lib/actions/action-send-email.ts
@@ -81,13 +81,13 @@ const handler: ActionDefinition['handler'] = async (
 		defaultEnvironment.mail.options
 	) {
 		const client = new Mailgun(defaultEnvironment.mail.options);
-		const response = await client.sendEmail({
+		await client.sendEmail({
 			toAddress,
 			fromAddress,
 			subject,
 			html,
 		});
-		return response;
+		return null;
 	} else {
 		throw new Error('Mail integration not found');
 	}

--- a/lib/actions/action-send-email.ts
+++ b/lib/actions/action-send-email.ts
@@ -1,13 +1,8 @@
 import { defaultEnvironment } from '@balena/jellyfish-environment';
-import type { Contract } from '@balena/jellyfish-types/build/core';
 import type { ActionDefinition } from '@balena/jellyfish-worker';
 import { MailOptions } from '@balena/jellyfish-environment';
 import axios from 'axios';
 import FormData from 'form-data';
-
-const MAIL_OPTIONS = defaultEnvironment.mail.options || {
-	domain: '',
-};
 
 interface SendEmailOptions {
 	toAddress: string;
@@ -71,33 +66,6 @@ class Mailgun {
 			headers: form.getHeaders(),
 		});
 	}
-}
-
-/**
- * @summary Build and return send email request options.
- * @function
- *
- * @param userCard - user to send email to
- * @param subject - email subject
- * @param html - email body HTML
- * @returns send email request options
- */
-export function buildSendEmailOptions(
-	userCard: Contract,
-	subject: string,
-	html: string,
-): SendEmailOptions {
-	let userEmail = userCard.data.email;
-	if (Array.isArray(userEmail)) {
-		userEmail = userEmail[0];
-	}
-
-	return {
-		fromAddress: `no-reply@${MAIL_OPTIONS.domain}`,
-		toAddress: userEmail as string,
-		subject,
-		html,
-	};
 }
 
 const handler: ActionDefinition['handler'] = async (

--- a/lib/actions/action-send-first-time-login-link.ts
+++ b/lib/actions/action-send-first-time-login-link.ts
@@ -12,7 +12,8 @@ import {
 } from '@balena/jellyfish-worker';
 import { get, includes, intersectionBy } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { actionSendEmail, buildSendEmailOptions } from './action-send-email';
+import { actionSendEmail } from './action-send-email';
+import { buildSendEmailOptions } from './mail-utils';
 import { addLinkCard } from './utils';
 
 const logger = getLogger(__filename);

--- a/lib/actions/mail-utils.ts
+++ b/lib/actions/mail-utils.ts
@@ -1,0 +1,33 @@
+import { defaultEnvironment } from '@balena/jellyfish-environment';
+import type { Contract } from '@balena/jellyfish-types/build/core';
+
+const MAIL_OPTIONS = defaultEnvironment.mail.options || {
+	domain: '',
+};
+
+/**
+ * @summary Build and return send email request options.
+ * @function
+ *
+ * @param userCard - user to send email to
+ * @param subject - email subject
+ * @param html - email body HTML
+ * @returns send email request options
+ */
+export function buildSendEmailOptions(
+	userCard: Contract,
+	subject: string,
+	html: string,
+) {
+	let userEmail = userCard.data.email;
+	if (Array.isArray(userEmail)) {
+		userEmail = userEmail[0];
+	}
+
+	return {
+		fromAddress: `no-reply@${MAIL_OPTIONS.domain}`,
+		toAddress: userEmail as string,
+		subject,
+		html,
+	};
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@balena/jellyfish-assert": "^1.2.13",
     "@balena/jellyfish-core": "^14.2.4",
     "@balena/jellyfish-logger": "4.0.32",
-    "@balena/jellyfish-mail": "^2.0.172",
     "@balena/jellyfish-worker": "^18.5.4",
     "axios": "^0.25.0",
     "bcrypt": "^5.0.1",

--- a/test/integration/actions/action-send-email.spec.ts
+++ b/test/integration/actions/action-send-email.spec.ts
@@ -1,11 +1,15 @@
 import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import _ from 'lodash';
+import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionSendEmail } from '../../../lib/actions/action-send-email';
-import { makeHandlerRequest } from './helpers';
+import { includes, makeHandlerRequest } from './helpers';
 
+const MAIL_OPTIONS = defaultEnvironment.mail.options;
+let mailBody: string = '';
 const handler = actionSendEmail.handler;
 let ctx: testUtils.TestContext;
 let actionContext: WorkerContext;
@@ -19,24 +23,49 @@ beforeAll(async () => {
 	});
 });
 
-afterAll(async () => {
+afterEach(() => {
+	nock.cleanAll();
+});
+
+afterAll(() => {
 	return testUtils.destroyContext(ctx);
 });
 
+function nockMail() {
+	nock(`${MAIL_OPTIONS!.baseUrl}/${MAIL_OPTIONS!.domain}`)
+		.persist()
+		.post('/messages')
+		.basicAuth({
+			user: 'api',
+			pass: MAIL_OPTIONS!.token,
+		})
+		.reply(200, (_uri: string, sendBody: string) => {
+			mailBody = sendBody;
+		});
+}
+
 describe('action-send-email', () => {
 	test('should send an email', async () => {
-		const result = await handler(
-			ctx.session,
-			actionContext,
-			{} as any,
-			makeHandlerRequest(ctx, actionSendEmail.contract, {
-				toAddress: 'test1@balenateam.m8r.co',
-				fromAddress: 'hello@balena.io',
-				subject: 'sending real email',
-				html: 'with real text in the body',
-			}),
-		);
-		expect(_.get(result, ['data', 'message'])).toEqual('Queued. Thank you.');
+		nockMail();
+		const user = await ctx.createUser('foobar');
+		const args = {
+			toAddress: 'foo@example.com',
+			fromAddress: 'bar@example.com',
+			subject: coreTestUtils.generateRandomId(),
+			html: coreTestUtils.generateRandomId(),
+		};
+		await ctx.processAction(ctx.session, {
+			action: 'action-send-email@1.0.0',
+			logContext: ctx.logContext,
+			card: user.id,
+			type: user.type,
+			arguments: args,
+		});
+
+		expect(includes('to', args.toAddress, mailBody)).toBe(true);
+		expect(includes('from', args.fromAddress, mailBody)).toBe(true);
+		expect(includes('subject', args.subject, mailBody)).toBe(true);
+		expect(includes('html', args.html, mailBody)).toBe(true);
 	});
 
 	test('should throw an error when the email is invalid', async () => {

--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -48,12 +48,12 @@ beforeAll(async () => {
 	);
 });
 
-afterAll(async () => {
-	return testUtils.destroyContext(ctx);
+afterEach(() => {
+	nock.cleanAll();
 });
 
-afterEach(async () => {
-	nock.cleanAll();
+afterAll(() => {
+	return testUtils.destroyContext(ctx);
 });
 
 function nockRequest() {


### PR DESCRIPTION
The abstraction inside `jellyfish-mail` can be held entirely inside the
`action-send-email` action, allowing us to archive the whole
`jellyfish-mail` repo.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>