### PR TITLE
Allow external user to view all views

### DIFF
--- a/lib/contracts/role-user-external-support.ts
+++ b/lib/contracts/role-user-external-support.ts
@@ -124,6 +124,7 @@ export const roleUserExternalSupport: RoleContractDefinition = {
 								'subscription',
 								'create',
 								'update',
+								'view',
 							],
 						},
 						type: {
@@ -156,6 +157,27 @@ export const roleUserExternalSupport: RoleContractDefinition = {
 						type: {
 							type: 'string',
 							const: 'action@1.0.0',
+						},
+						data: {
+							type: 'object',
+							additionalProperties: true,
+						},
+					},
+				},
+				{
+					type: 'object',
+					required: ['id', 'slug', 'type', 'data'],
+					properties: {
+						id: {
+							type: 'string',
+						},
+						slug: {
+							type: 'string',
+							enum: ['view-all-views'],
+						},
+						type: {
+							type: 'string',
+							const: 'view@1.0.0',
 						},
 						data: {
 							type: 'object',

--- a/test/integration/contracts/role-user-external-support.spec.ts
+++ b/test/integration/contracts/role-user-external-support.spec.ts
@@ -195,6 +195,7 @@ describe('role-user-community', () => {
 			'subscription',
 			'support-thread',
 			'update',
+			'view',
 		]);
 	});
 });


### PR DESCRIPTION
Change-type: minor

---

Allow external support to view all views (`view-all-views` contract), otherwise, when logged in jellyfish, these users will see infinite loading indicator.