### PR TITLE
Allow null for name field

### DIFF
--- a/lib/contracts/account.ts
+++ b/lib/contracts/account.ts
@@ -18,7 +18,7 @@ export const account: ContractDefinition = {
 					},
 				},
 				name: {
-					type: 'string',
+					type: ['string', 'null'],
 					fullTextSearch: true,
 				},
 				data: {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Allow `null` type for top-level `name` field for `account` contracts. We have a number of `account` contracts already in the database in which `name` is `null`, which means that patch attempts result in schema validation failures with `- data.name should be string`. As far as I know though, we don't actually *need* this field to be populated.

More context: https://www.flowdock.com/app/rulemotion/resin-devops/threads/nU8MaGjPtP_cWWGOQI5rhW1X5dY