### PR TITLE
Filter out discussions from forum support view

### DIFF
--- a/lib/contracts/view-all-forum-threads.ts
+++ b/lib/contracts/view-all-forum-threads.ts
@@ -58,8 +58,14 @@ export const viewAllForumThreads: ViewContractDefinition = {
 						},
 						data: {
 							type: 'object',
-							required: ['mirrors'],
+							required: ['inbox', 'mirrors'],
 							properties: {
+								inbox: {
+									type: 'string',
+									not: {
+										const: 'Discussions',
+									},
+								},
 								mirrors: {
 									type: 'array',
 									items: {


### PR DESCRIPTION
Blog discussion threads are to be managed in
the new "Blog Disussions" channel. Removing
them from forum support thread view to avoid
confusion.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>