### PR TITLE
Use events mixin for pipeline and checkin contracts

### DIFF
--- a/lib/contracts/checkin.ts
+++ b/lib/contracts/checkin.ts
@@ -26,10 +26,15 @@ const getFormUiSchema = () => ({
 	},
 });
 
-export const checkin: ContractDefinition = {
-	slug: 'checkin',
+const slug = 'checkin';
+const type = 'type@1.0.0';
+
+export const checkin: ContractDefinition = cardMixins.mixin(
+	cardMixins.withEvents(slug, type),
+)({
+	slug,
 	name: 'Checkin',
-	type: 'type@1.0.0',
+	type,
 	markers: [],
 	data: {
 		schema: {
@@ -39,13 +44,6 @@ export const checkin: ContractDefinition = {
 					type: 'string',
 					pattern: '^.*\\S.*$',
 					fullTextSearch: true,
-				},
-				tags: {
-					type: 'array',
-					items: {
-						type: 'string',
-					},
-					$$formula: "AGGREGATE($events, 'tags')",
 				},
 				data: {
 					type: 'object',
@@ -187,4 +185,4 @@ export const checkin: ContractDefinition = {
 			create: getFormUiSchema(),
 		},
 	},
-};
+});

--- a/lib/contracts/pipeline.ts
+++ b/lib/contracts/pipeline.ts
@@ -1,9 +1,15 @@
+import { cardMixins } from '@balena/jellyfish-core';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
-export const pipeline: ContractDefinition = {
-	slug: 'pipeline',
+const slug = 'pipeline';
+const type = 'type@1.0.0';
+
+export const pipeline: ContractDefinition = cardMixins.mixin(
+	cardMixins.withEvents(slug, type),
+)({
+	slug,
 	name: 'Pipeline',
-	type: 'type@1.0.0',
+	type,
 	markers: [],
 	data: {
 		schema: {
@@ -13,13 +19,6 @@ export const pipeline: ContractDefinition = {
 					type: 'string',
 					pattern: '^.*\\S.*$',
 					fullTextSearch: true,
-				},
-				tags: {
-					type: 'array',
-					items: {
-						type: 'string',
-					},
-					$$formula: "AGGREGATE($events, 'tags')",
 				},
 				data: {
 					type: 'object',
@@ -42,4 +41,4 @@ export const pipeline: ContractDefinition = {
 			},
 		},
 	},
-};
+});


### PR DESCRIPTION
In the future, the $events syntactic sugar will be removed from formulas.
This change switches formulas that were using $events for tag
aggregation to use the withEvents mixin instead.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>