### PR TITLE
Use autumndb instead of jellyfish-core

### DIFF
--- a/lib/actions/action-complete-first-time-login.ts
+++ b/lib/actions/action-complete-first-time-login.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from '@balena/jellyfish-core';
+import { errors as coreErrors } from 'autumndb';
 import { getLogger } from '@balena/jellyfish-logger';
 import type {
 	Contract,

--- a/lib/actions/action-complete-password-reset.ts
+++ b/lib/actions/action-complete-password-reset.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from '@balena/jellyfish-core';
+import { errors as coreErrors } from 'autumndb';
 import type {
 	Contract,
 	TypeContract,

--- a/lib/actions/action-set-password.ts
+++ b/lib/actions/action-set-password.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from '@balena/jellyfish-core';
+import { errors as coreErrors } from 'autumndb';
 import type { TypeContract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionDefinition,

--- a/lib/contracts/account.ts
+++ b/lib/contracts/account.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const account: ContractDefinition = {

--- a/lib/contracts/blog-post.ts
+++ b/lib/contracts/blog-post.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const blogPost: ContractDefinition = {

--- a/lib/contracts/brainstorm-call.ts
+++ b/lib/contracts/brainstorm-call.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const brainstormCall: ContractDefinition = {

--- a/lib/contracts/brainstorm-topic.ts
+++ b/lib/contracts/brainstorm-topic.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'brainstorm-topic';

--- a/lib/contracts/checkin.ts
+++ b/lib/contracts/checkin.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const getFormUiSchema = () => ({

--- a/lib/contracts/contact.ts
+++ b/lib/contracts/contact.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const contact: ContractDefinition = {

--- a/lib/contracts/improvement.ts
+++ b/lib/contracts/improvement.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/lib/contracts/message.ts
+++ b/lib/contracts/message.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const message: ContractDefinition = {

--- a/lib/contracts/milestone.ts
+++ b/lib/contracts/milestone.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'milestone';

--- a/lib/contracts/opportunity.ts
+++ b/lib/contracts/opportunity.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'opportunity';

--- a/lib/contracts/pattern.ts
+++ b/lib/contracts/pattern.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'pattern';

--- a/lib/contracts/pipeline.ts
+++ b/lib/contracts/pipeline.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'pipeline';

--- a/lib/contracts/project.ts
+++ b/lib/contracts/project.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'project';

--- a/lib/contracts/rating.ts
+++ b/lib/contracts/rating.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const getFormUiSchema = () => ({

--- a/lib/contracts/saga.ts
+++ b/lib/contracts/saga.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'saga';

--- a/lib/contracts/sales-thread.ts
+++ b/lib/contracts/sales-thread.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'sales-thread';

--- a/lib/contracts/support-thread.ts
+++ b/lib/contracts/support-thread.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'support-thread';

--- a/lib/contracts/thread.ts
+++ b/lib/contracts/thread.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'thread';

--- a/lib/contracts/whisper.ts
+++ b/lib/contracts/whisper.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 export const whisper: ContractDefinition = {

--- a/lib/contracts/workflow.ts
+++ b/lib/contracts/workflow.ts
@@ -1,4 +1,4 @@
-import { cardMixins } from '@balena/jellyfish-core';
+import { cardMixins } from 'autumndb';
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 
 const slug = 'workflow';

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionDefinition,

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.18",
-    "@balena/jellyfish-core": "^16.0.13",
     "@balena/jellyfish-logger": "^5.0.6",
     "@balena/jellyfish-worker": "^20.0.2",
+    "autumndb": "^17.0.3",
     "axios": "^0.26.1",
     "bcrypt": "^5.0.1",
     "blueimp-md5": "^2.19.0",

--- a/repo.yml
+++ b/repo.yml
@@ -1,12 +1,12 @@
-type: 'node'
+type: "node"
 upstream:
-  - repo: 'jellyfish-assert'
-    url: 'https://github.com/product-os/jellyfish-assert'
-  - repo: 'jellyfish-environment'
-    url: 'https://github.com/product-os/jellyfish-environment'
-  - repo: 'jellyfish-logger'
-    url: 'https://github.com/product-os/jellyfish-logger'
-  - repo: 'jellyfish-core'
-    url: 'https://github.com/product-os/jellyfish-core'
-  - repo: 'jellyfish-worker'
-    url: 'https://github.com/product-os/jellyfish-worker'
+  - repo: "jellyfish-assert"
+    url: "https://github.com/product-os/jellyfish-assert"
+  - repo: "jellyfish-environment"
+    url: "https://github.com/product-os/jellyfish-environment"
+  - repo: "jellyfish-logger"
+    url: "https://github.com/product-os/jellyfish-logger"
+  - repo: "autumndb"
+    url: "https://github.com/product-os/autumndb"
+  - repo: "jellyfish-worker"
+    url: "https://github.com/product-os/jellyfish-worker"

--- a/test/integration/actions/action-broadcast.spec.ts
+++ b/test/integration/actions/action-broadcast.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { cloneDeep, isArray, isNull, map, pick, sortBy } from 'lodash';

--- a/test/integration/actions/action-complete-first-time-login.spec.ts
+++ b/test/integration/actions/action-complete-first-time-login.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/actions/action-complete-password-reset.spec.ts
+++ b/test/integration/actions/action-complete-password-reset.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/actions/action-delete-card.spec.ts
+++ b/test/integration/actions/action-delete-card.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/actions/action-google-meet.spec.ts
+++ b/test/integration/actions/action-google-meet.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { google } from 'googleapis';

--- a/test/integration/actions/action-increment-tag.spec.ts
+++ b/test/integration/actions/action-increment-tag.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { pick } from 'lodash';

--- a/test/integration/actions/action-increment.spec.ts
+++ b/test/integration/actions/action-increment.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import _ from 'lodash';

--- a/test/integration/actions/action-integration-import-event.spec.ts
+++ b/test/integration/actions/action-integration-import-event.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/actions/action-merge-draft-version.spec.ts
+++ b/test/integration/actions/action-merge-draft-version.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { isArray, isNull } from 'lodash';

--- a/test/integration/actions/action-oauth-associate.spec.ts
+++ b/test/integration/actions/action-oauth-associate.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { isArray, isNull } from 'lodash';

--- a/test/integration/actions/action-oauth-authorize.spec.ts
+++ b/test/integration/actions/action-oauth-authorize.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/actions/action-ping.spec.ts
+++ b/test/integration/actions/action-ping.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/actions/action-request-password-reset.spec.ts
+++ b/test/integration/actions/action-request-password-reset.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import nock from 'nock';

--- a/test/integration/actions/action-send-email.spec.ts
+++ b/test/integration/actions/action-send-email.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import {

--- a/test/integration/actions/action-set-password.spec.ts
+++ b/test/integration/actions/action-set-password.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { errors as workerErrors } from '@balena/jellyfish-worker';
 import bcrypt from 'bcrypt';

--- a/test/integration/actions/action-set-update.spec.ts
+++ b/test/integration/actions/action-set-update.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import { isArray, isNull } from 'lodash';

--- a/test/integration/actions/action-set-user-avatar.spec.ts
+++ b/test/integration/actions/action-set-user-avatar.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
 import md5 from 'blueimp-md5';

--- a/test/integration/actions/helpers.ts
+++ b/test/integration/actions/helpers.ts
@@ -1,4 +1,4 @@
-import { Kernel, testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { Kernel, testUtils as coreTestUtils } from 'autumndb';
 import type { ActionData } from '@balena/jellyfish-types/build/core';
 import {
 	ActionContractDefinition,

--- a/test/integration/actions/integrations/foobar.ts
+++ b/test/integration/actions/integrations/foobar.ts
@@ -1,4 +1,4 @@
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import type {
 	Integration,
 	IntegrationDefinition,

--- a/test/integration/actions/mirror.spec.ts
+++ b/test/integration/actions/mirror.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';

--- a/test/integration/contracts/role-user-community.spec.ts
+++ b/test/integration/contracts/role-user-community.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import _ from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/contracts/role-user-external-support.spec.ts
+++ b/test/integration/contracts/role-user-external-support.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import _ from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/contracts/support-thread.spec.ts
+++ b/test/integration/contracts/support-thread.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 

--- a/test/integration/contracts/triggered-action-increment-tag.spec.ts
+++ b/test/integration/contracts/triggered-action-increment-tag.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/contracts/triggered-action-support-completed-improvement-reopen.spec.ts
+++ b/test/integration/contracts/triggered-action-support-completed-improvement-reopen.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 

--- a/test/integration/contracts/triggered-action-support-reopen.spec.ts
+++ b/test/integration/contracts/triggered-action-support-reopen.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 

--- a/test/integration/contracts/triggered-action-support-summary.spec.ts
+++ b/test/integration/contracts/triggered-action-support-summary.spec.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 

--- a/test/integration/contracts/triggered-action-update-event-edited-at.spec.ts
+++ b/test/integration/contracts/triggered-action-update-event-edited-at.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { isBefore, isValid } from 'date-fns';
 import { defaultPlugin, testUtils } from '../../../lib';

--- a/test/integration/contracts/triggered-action-user-contact.spec.ts
+++ b/test/integration/contracts/triggered-action-user-contact.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 

--- a/test/integration/contracts/user-guest.spec.ts
+++ b/test/integration/contracts/user-guest.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 


### PR DESCRIPTION
The `jellyfish-core` package has been renamed to `autumndb`

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>