### PR TITLE
Update imports

### DIFF
--- a/lib/actions/action-complete-first-time-login.ts
+++ b/lib/actions/action-complete-first-time-login.ts
@@ -1,5 +1,4 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from 'autumndb';
 import { getLogger } from '@balena/jellyfish-logger';
 import type {
 	Contract,
@@ -11,6 +10,7 @@ import {
 	errors as workerErrors,
 	WorkerContext,
 } from '@balena/jellyfish-worker';
+import { errors as autumndbErrors } from 'autumndb';
 import { isNil } from 'lodash';
 import { actionCompletePasswordReset } from './action-complete-password-reset';
 import { PASSWORDLESS_USER_HASH } from './constants';
@@ -212,7 +212,7 @@ const handler: ActionDefinition['handler'] = async (
 
 			// A schema mismatch here means that the patch could
 			// not be applied to the card due to permissions.
-			if (error instanceof coreErrors.JellyfishSchemaMismatch) {
+			if (error instanceof autumndbErrors.JellyfishSchemaMismatch) {
 				// TS-TODO: Ensure this error is what is expected with Context type
 				const newError = new workerErrors.WorkerAuthenticationError(
 					'Password change not allowed',

--- a/lib/actions/action-complete-password-reset.ts
+++ b/lib/actions/action-complete-password-reset.ts
@@ -1,5 +1,4 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from 'autumndb';
 import type {
 	Contract,
 	TypeContract,
@@ -10,6 +9,7 @@ import {
 	errors as workerErrors,
 	WorkerContext,
 } from '@balena/jellyfish-worker';
+import { errors as autumndbErrors } from 'autumndb';
 import bcrypt from 'bcrypt';
 import { BCRYPT_SALT_ROUNDS } from './constants';
 
@@ -186,7 +186,7 @@ const handler: ActionDefinition['handler'] = async (
 		.catch((error: unknown) => {
 			// A schema mismatch here means that the patch could
 			// not be applied to the card due to permissions.
-			if (error instanceof coreErrors.JellyfishSchemaMismatch) {
+			if (error instanceof autumndbErrors.JellyfishSchemaMismatch) {
 				// TS-TODO: Ensure this error is what is expected with Context type
 				const newError = new workerErrors.WorkerAuthenticationError(
 					'Password change not allowed',

--- a/lib/actions/action-set-password.ts
+++ b/lib/actions/action-set-password.ts
@@ -1,11 +1,11 @@
 import * as assert from '@balena/jellyfish-assert';
-import { errors as coreErrors } from 'autumndb';
 import type { TypeContract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionDefinition,
 	actions,
 	errors as workerErrors,
 } from '@balena/jellyfish-worker';
+import { errors as autumndbErrors } from 'autumndb';
 import bcrypt from 'bcrypt';
 import { isEmpty } from 'lodash';
 import { BCRYPT_SALT_ROUNDS, PASSWORDLESS_USER_HASH } from './constants';
@@ -91,7 +91,7 @@ const handler: ActionDefinition['handler'] = async (
 		.catch((error: unknown) => {
 			// A schema mismatch here means that the patch could
 			// not be applied to the card due to permissions.
-			if (error instanceof coreErrors.JellyfishSchemaMismatch) {
+			if (error instanceof autumndbErrors.JellyfishSchemaMismatch) {
 				const newError = new workerErrors.WorkerAuthenticationError(
 					'Password change not allowed',
 				);

--- a/lib/contracts/triggered-action-hangouts-link.ts
+++ b/lib/contracts/triggered-action-hangouts-link.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionHangoutsLink: TriggeredActionContractDefinition = {
 	slug: 'triggered-action-hangouts-link',

--- a/lib/contracts/triggered-action-increment-tag.ts
+++ b/lib/contracts/triggered-action-increment-tag.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionIncrementTag: TriggeredActionContractDefinition = {
 	slug: 'triggered-action-increment-tag',

--- a/lib/contracts/triggered-action-integration-import-event.ts
+++ b/lib/contracts/triggered-action-integration-import-event.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionIntegrationImportEvent: TriggeredActionContractDefinition =
 	{

--- a/lib/contracts/triggered-action-set-user-avatar.ts
+++ b/lib/contracts/triggered-action-set-user-avatar.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionSetUserAvatar: TriggeredActionContractDefinition = {
 	slug: 'triggered-action-set-user-avatar',

--- a/lib/contracts/triggered-action-support-completed-improvement-reopen.ts
+++ b/lib/contracts/triggered-action-support-completed-improvement-reopen.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 const IMPROVEMENT_COMPLETE_STATUS = 'completed';
 

--- a/lib/contracts/triggered-action-support-reopen.ts
+++ b/lib/contracts/triggered-action-support-reopen.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionSupportReopen: TriggeredActionContractDefinition = {
 	slug: 'triggered-action-support-reopen',

--- a/lib/contracts/triggered-action-support-summary.ts
+++ b/lib/contracts/triggered-action-support-summary.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionSupportSummary: TriggeredActionContractDefinition =
 	{

--- a/lib/contracts/triggered-action-sync-thread-post-link-whisper.ts
+++ b/lib/contracts/triggered-action-sync-thread-post-link-whisper.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionSyncThreadPostLinkWhisper: TriggeredActionContractDefinition =
 	{

--- a/lib/contracts/triggered-action-update-event-edited-at.ts
+++ b/lib/contracts/triggered-action-update-event-edited-at.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionUpdateEventEditedAt: TriggeredActionContractDefinition =
 	{

--- a/lib/contracts/triggered-action-user-contact.ts
+++ b/lib/contracts/triggered-action-user-contact.ts
@@ -1,4 +1,4 @@
-import type { TriggeredActionContractDefinition } from '@balena/jellyfish-types/build/worker';
+import type { TriggeredActionContractDefinition } from '@balena/jellyfish-worker';
 
 export const triggeredActionUserContact: TriggeredActionContractDefinition = {
 	slug: 'triggered-action-user-contact',

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,10 +1,10 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionDefinition,
 	PluginDefinition,
 	testUtils as workerTestUtils,
 } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 
 /**
@@ -35,7 +35,7 @@ export interface TestContext extends workerTestUtils.TestContext {
 /**
  * Options accepted by `newContext`.
  */
-export interface NewContextOptions extends coreTestUtils.NewContextOptions {
+export interface NewContextOptions extends autumndbTestUtils.NewContextOptions {
 	/**
 	 * Set of plugins needed to run tests.
 	 */

--- a/test/integration/actions/action-broadcast.spec.ts
+++ b/test/integration/actions/action-broadcast.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { cloneDeep, isArray, isNull, map, pick, sortBy } from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionBroadcast } from '../../../lib/actions/action-broadcast';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -29,7 +29,7 @@ describe('action-broadcast', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -38,19 +38,19 @@ describe('action-broadcast', () => {
 			ctx.adminUserId,
 			ctx.session,
 			supportThread,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 		);
 
 		expect.hasAssertions();
 		const result = await handler(ctx.session, actionContext, message, {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
-				message: coreTestUtils.generateRandomId(),
+				message: autumndbTestUtils.generateRandomId(),
 			},
 		} as any);
 		if (!isNull(result) && !isArray(result)) {
@@ -60,11 +60,11 @@ describe('action-broadcast', () => {
 
 	test('should return null on matched message', async () => {
 		// Create a thread with a matching message already linked
-		const body = coreTestUtils.generateRandomSlug();
+		const body = autumndbTestUtils.generateRandomSlug();
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -79,11 +79,11 @@ describe('action-broadcast', () => {
 		// Execute action and check that no new message was broadcast
 		const result = await handler(ctx.session, actionContext, supportThread, {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				message: (message as any).data.payload.message,
 			},
@@ -93,17 +93,17 @@ describe('action-broadcast', () => {
 
 	test('should throw an error on invalid session', async () => {
 		const localContext = cloneDeep(actionContext);
-		const session = coreTestUtils.generateRandomId();
+		const session = autumndbTestUtils.generateRandomId();
 		localContext.privilegedSession = session;
 
 		await expect(
 			handler(session, localContext, ctx.worker.typeContracts['user@1.0.0'], {
 				context: {
-					id: `TEST-${coreTestUtils.generateRandomId()}`,
+					id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 				},
 				timestamp: new Date().toISOString(),
 				actor: ctx.adminUserId,
-				originator: coreTestUtils.generateRandomId(),
+				originator: autumndbTestUtils.generateRandomId(),
 				arguments: {},
 			} as any),
 		).rejects.toThrow();
@@ -113,7 +113,7 @@ describe('action-broadcast', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -189,7 +189,7 @@ describe('action-broadcast', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -198,7 +198,7 @@ describe('action-broadcast', () => {
 			ctx.adminUserId,
 			ctx.session,
 			supportThread,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 		);
 
 		const request = await ctx.queue.producer.enqueue(
@@ -272,7 +272,7 @@ describe('action-broadcast', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -374,7 +374,7 @@ describe('action-broadcast', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -405,7 +405,7 @@ describe('action-broadcast', () => {
 			ctx.adminUserId,
 			ctx.session,
 			supportThread,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 		);
 
 		const message2 = 'Broadcast test 2';

--- a/test/integration/actions/action-complete-first-time-login.spec.ts
+++ b/test/integration/actions/action-complete-first-time-login.spec.ts
@@ -1,8 +1,8 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionCompleteFirstTimeLogin } from '../../../lib/actions/action-complete-first-time-login';
@@ -21,7 +21,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 
 	// Get org and add test user as member
@@ -65,7 +65,7 @@ afterEach(async () => {
 describe('action-complete-first-time-login', () => {
 	test("should update the user's password when the firstTimeLoginToken is valid", async () => {
 		const user = await ctx.createUser(
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			PASSWORDLESS_USER_HASH,
 		);
 		const session = await ctx.createSession(user);
@@ -97,7 +97,7 @@ describe('action-complete-first-time-login', () => {
 		});
 
 		// TODO: temporary workaround for context/logContext mismatch
-		const newPassword = coreTestUtils.generateRandomId();
+		const newPassword = autumndbTestUtils.generateRandomId();
 		const completeFirstTimeLoginAction = (await ctx.worker.pre(ctx.session, {
 			action: 'action-complete-first-time-login@1.0.0',
 			logContext: ctx.logContext,
@@ -122,7 +122,7 @@ describe('action-complete-first-time-login', () => {
 	});
 
 	test('should fail when the first-time login does not match a valid card', async () => {
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -132,7 +132,7 @@ describe('action-complete-first-time-login', () => {
 			'has member',
 		);
 
-		const fakeToken = coreTestUtils.generateRandomId();
+		const fakeToken = autumndbTestUtils.generateRandomId();
 		await expect(
 			ctx.processAction(ctx.session, {
 				action: 'action-complete-first-time-login@1.0.0',
@@ -141,14 +141,14 @@ describe('action-complete-first-time-login', () => {
 				type: user.type,
 				arguments: {
 					firstTimeLoginToken: fakeToken,
-					newPassword: coreTestUtils.generateRandomId(),
+					newPassword: autumndbTestUtils.generateRandomId(),
 				},
 			}),
 		).rejects.toThrowError();
 	});
 
 	test('should fail when the first-time login token has expired', async () => {
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -217,14 +217,14 @@ describe('action-complete-first-time-login', () => {
 				type: user.type,
 				arguments: {
 					firstTimeLoginToken: match.data.firstTimeLoginToken,
-					newPassword: coreTestUtils.generateRandomId(),
+					newPassword: autumndbTestUtils.generateRandomId(),
 				},
 			}),
 		).rejects.toThrowError();
 	});
 
 	test('should fail when the first-time login is not active', async () => {
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -280,7 +280,7 @@ describe('action-complete-first-time-login', () => {
 				type: user.type,
 				arguments: {
 					firstTimeLoginToken: match.data.firstTimeLoginToken,
-					newPassword: coreTestUtils.generateRandomId(),
+					newPassword: autumndbTestUtils.generateRandomId(),
 				},
 			}),
 		).rejects.toThrowError();
@@ -288,7 +288,7 @@ describe('action-complete-first-time-login', () => {
 
 	test('should fail if the user becomes inactive between requesting and completing the first-time login', async () => {
 		const user = await ctx.createUser(
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			PASSWORDLESS_USER_HASH,
 		);
 		const session = await ctx.createSession(user);
@@ -327,7 +327,7 @@ describe('action-complete-first-time-login', () => {
 			},
 		});
 
-		const newPassword = coreTestUtils.generateRandomId();
+		const newPassword = autumndbTestUtils.generateRandomId();
 		const completeFirstTimeLoginAction = (await ctx.worker.pre(ctx.session, {
 			action: 'action-complete-first-time-login@1.0.0',
 			logContext: ctx.logContext,
@@ -348,7 +348,7 @@ describe('action-complete-first-time-login', () => {
 
 	test('should invalidate the first-time-login card', async () => {
 		const user = await ctx.createUser(
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			PASSWORDLESS_USER_HASH,
 		);
 		await ctx.createLinkThroughWorker(
@@ -401,7 +401,7 @@ describe('action-complete-first-time-login', () => {
 			user,
 			makeHandlerRequest(ctx, actionCompleteFirstTimeLogin.contract, {
 				firstTimeLoginToken: firstTimeLogin.data.firstTimeLoginToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			}),
 		);
 
@@ -416,8 +416,8 @@ describe('action-complete-first-time-login', () => {
 
 	test('should throw an error when the user already has a password set', async () => {
 		const user = await ctx.createUser(
-			coreTestUtils.generateRandomSlug(),
-			coreTestUtils.generateRandomId(),
+			autumndbTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomId(),
 		);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -465,7 +465,7 @@ describe('action-complete-first-time-login', () => {
 				type: user.type,
 				arguments: {
 					firstTimeLoginToken: match.data.firstTimeLoginToken,
-					newPassword: coreTestUtils.generateRandomId(),
+					newPassword: autumndbTestUtils.generateRandomId(),
 				},
 			}),
 		).rejects.toThrowError();

--- a/test/integration/actions/action-complete-password-reset.spec.ts
+++ b/test/integration/actions/action-complete-password-reset.spec.ts
@@ -1,8 +1,8 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import bcrypt from 'bcrypt';
 import crypto from 'crypto';
 import { isArray, isNull } from 'lodash';
@@ -29,7 +29,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 
 	// Get org and add test user as member
@@ -74,7 +74,7 @@ afterEach(() => {
 
 describe('action-complete-password-reset', () => {
 	test('should hash new password', async () => {
-		const plaintext = coreTestUtils.generateRandomId();
+		const plaintext = autumndbTestUtils.generateRandomId();
 		const request = makePreRequest(ctx, actionCompletePasswordReset.contract, {
 			requestArguments: { newPassword: plaintext },
 		});
@@ -90,7 +90,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should replace the user password when the requestToken is valid', async () => {
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, hash);
 		const session = await ctx.createSession(user);
 
@@ -112,7 +112,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 
@@ -135,7 +135,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should fail when the reset token does not match a valid card', async () => {
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 
 		const completePasswordReset = (await ctx.worker.pre(ctx.session, {
 			action: 'action-complete-password-reset@1.0.0',
@@ -144,7 +144,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken: 'fake-reset-token',
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 		completePasswordReset.logContext = completePasswordReset.context;
@@ -155,7 +155,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should fail when the reset token has expired', async () => {
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, hash);
 
 		await ctx.processAction(ctx.session, {
@@ -233,7 +233,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 
@@ -246,7 +246,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should fail when the reset token is not active', async () => {
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, hash);
 		await ctx.processAction(ctx.session, {
 			action: 'action-request-password-reset@1.0.0',
@@ -311,7 +311,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 
@@ -324,7 +324,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should fail if the user becomes inactive between requesting and completing the password reset', async () => {
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, hash);
 		const session = await ctx.createSession(user);
 
@@ -355,7 +355,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 
@@ -369,7 +369,7 @@ describe('action-complete-password-reset', () => {
 	});
 
 	test('should soft delete password reset card', async () => {
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, hash);
 
 		const requestPasswordReset = await ctx.processAction(ctx.session, {
@@ -390,7 +390,7 @@ describe('action-complete-password-reset', () => {
 			type: user.type,
 			arguments: {
 				resetToken,
-				newPassword: coreTestUtils.generateRandomId(),
+				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;
 

--- a/test/integration/actions/action-delete-card.spec.ts
+++ b/test/integration/actions/action-delete-card.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionDeleteCard } from '../../../lib/actions/action-delete-card';
 import { makeHandlerRequest } from './helpers';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -34,8 +34,8 @@ describe('action-delete-card', () => {
 				actor: ctx.adminUserId,
 			},
 			{
-				name: coreTestUtils.generateRandomSlug(),
-				slug: coreTestUtils.generateRandomSlug({
+				name: autumndbTestUtils.generateRandomSlug(),
+				slug: autumndbTestUtils.generateRandomSlug({
 					prefix: 'card',
 				}),
 				active: false,

--- a/test/integration/actions/action-google-meet.spec.ts
+++ b/test/integration/actions/action-google-meet.spec.ts
@@ -1,6 +1,6 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { google } from 'googleapis';
 import sinon from 'sinon';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -17,7 +17,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -56,21 +56,21 @@ describe('action-google-meet', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
 		);
 
 		stub({
-			id: coreTestUtils.generateRandomId(),
+			id: autumndbTestUtils.generateRandomId(),
 		});
 
 		const message = await ctx.createMessage(
 			ctx.adminUserId,
 			ctx.session,
 			supportThread,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 		);
 		await expect(
 			handler(
@@ -88,7 +88,7 @@ describe('action-google-meet', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -96,14 +96,14 @@ describe('action-google-meet', () => {
 
 		stub({
 			hangoutLink: conferenceUrl,
-			id: coreTestUtils.generateRandomId(),
+			id: autumndbTestUtils.generateRandomId(),
 		});
 
 		const message = await ctx.createMessage(
 			ctx.adminUserId,
 			ctx.session,
 			supportThread,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 		);
 		message.type = 'foobar';
 		await expect(
@@ -120,7 +120,7 @@ describe('action-google-meet', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},
@@ -143,7 +143,7 @@ describe('action-google-meet', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 			},

--- a/test/integration/actions/action-increment-tag.spec.ts
+++ b/test/integration/actions/action-increment-tag.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { pick } from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionIncrementTag } from '../../../lib/actions/action-increment-tag';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -29,7 +29,7 @@ describe('action-increment-tag', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'tag@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				count: 0,
 			},
@@ -37,11 +37,11 @@ describe('action-increment-tag', () => {
 
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				name: tag.slug.replace(/^tag-/, ''),
 			},
@@ -69,7 +69,7 @@ describe('action-increment-tag', () => {
 	});
 
 	test('should create a new tag if one does not exist', async () => {
-		const name = `tag-${coreTestUtils.generateRandomId()}`;
+		const name = `tag-${autumndbTestUtils.generateRandomId()}`;
 		const id = await ctx.queue.producer.enqueue(
 			ctx.worker.getId(),
 			ctx.session,

--- a/test/integration/actions/action-increment.spec.ts
+++ b/test/integration/actions/action-increment.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionIncrement } from '../../../lib/actions/action-increment';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -29,7 +29,7 @@ describe('action-increment', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'card@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{},
 		);
 		contract.type = 'foobar@1.0.0';
@@ -37,11 +37,11 @@ describe('action-increment', () => {
 		await expect(
 			handler(ctx.session, actionContext, contract, {
 				context: {
-					id: `TEST-${coreTestUtils.generateRandomId()}`,
+					id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 				},
 				timestamp: new Date().toISOString(),
 				actor: ctx.adminUserId,
-				originator: coreTestUtils.generateRandomId(),
+				originator: autumndbTestUtils.generateRandomId(),
 				arguments: {},
 			} as any),
 		).rejects.toThrow();
@@ -52,7 +52,7 @@ describe('action-increment', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'card@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				count: 0,
 			},
@@ -60,11 +60,11 @@ describe('action-increment', () => {
 
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				path: ['data', 'count'],
 			},
@@ -99,7 +99,7 @@ describe('action-increment', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'card@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				count: 'foobar',
 			},
@@ -107,11 +107,11 @@ describe('action-increment', () => {
 
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				path: ['data', 'count'],
 			},

--- a/test/integration/actions/action-integration-import-event.spec.ts
+++ b/test/integration/actions/action-integration-import-event.spec.ts
@@ -1,7 +1,7 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isArray } from 'lodash';
 import sinon from 'sinon';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -21,13 +21,13 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin(), foobarPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 
 	supportThread = await ctx.createSupportThread(
 		ctx.adminUserId,
 		ctx.session,
-		coreTestUtils.generateRandomSlug(),
+		autumndbTestUtils.generateRandomSlug(),
 		{
 			status: 'open',
 			source,

--- a/test/integration/actions/action-merge-draft-version.spec.ts
+++ b/test/integration/actions/action-merge-draft-version.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isArray, isNull } from 'lodash';
 import * as semver from 'semver';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -17,7 +17,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -36,8 +36,8 @@ describe('action-merge-draft-version', () => {
 				actor: ctx.adminUserId,
 			},
 			{
-				name: coreTestUtils.generateRandomSlug(),
-				slug: coreTestUtils.generateRandomSlug({
+				name: autumndbTestUtils.generateRandomSlug(),
+				slug: autumndbTestUtils.generateRandomSlug({
 					prefix: 'card',
 				}),
 				version: '1.0.2-beta1+rev02',
@@ -83,8 +83,8 @@ describe('action-merge-draft-version', () => {
 				actor: ctx.adminUserId,
 			},
 			{
-				name: coreTestUtils.generateRandomSlug(),
-				slug: coreTestUtils.generateRandomSlug({
+				name: autumndbTestUtils.generateRandomSlug(),
+				slug: autumndbTestUtils.generateRandomSlug({
 					prefix: 'card',
 				}),
 				version: '1.0.2-beta1+rev02',

--- a/test/integration/actions/action-oauth-associate.spec.ts
+++ b/test/integration/actions/action-oauth-associate.spec.ts
@@ -1,6 +1,6 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isArray, isNull } from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionOAuthAssociate } from '../../../lib/actions/action-oauth-associate';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin(), foobarPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -29,20 +29,20 @@ describe('action-oauth-associate', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 			},
 		);
 
 		const result: any = await handler(ctx.session, actionContext, user, {
 			logContext: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				provider: 'foobar',
 			},

--- a/test/integration/actions/action-oauth-authorize.spec.ts
+++ b/test/integration/actions/action-oauth-authorize.spec.ts
@@ -1,8 +1,8 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isEmpty, isString } from 'lodash';
 import nock from 'nock';
 import sinon from 'sinon';
@@ -20,7 +20,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin(), foobarPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -41,7 +41,7 @@ describe('action-oauth-authorize', () => {
 		assert(foobarIntegrationDefinition.OAUTH_BASE_URL);
 		nock(foobarIntegrationDefinition.OAUTH_BASE_URL)
 			.post('/oauth/token')
-			.reply(200, coreTestUtils.generateRandomId());
+			.reply(200, autumndbTestUtils.generateRandomId());
 
 		sinon.stub(defaultEnvironment, 'getIntegration').callsFake(() => {
 			return {
@@ -54,23 +54,23 @@ describe('action-oauth-authorize', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 			},
 		);
 
 		const result = await handler(ctx.session, actionContext, user, {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				provider: 'foobar',
-				code: coreTestUtils.generateRandomId(),
+				code: autumndbTestUtils.generateRandomId(),
 				origin: 'http://localhost',
 			},
 		} as any);

--- a/test/integration/actions/action-ping.spec.ts
+++ b/test/integration/actions/action-ping.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionPing } from '../../../lib/actions/action-ping';
 
@@ -14,7 +14,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -26,9 +26,9 @@ describe('action-ping', () => {
 	test('should update specified contract', async () => {
 		// Create ping contract
 		const ping = await ctx.kernel.insertContract(ctx.logContext, ctx.session, {
-			id: coreTestUtils.generateRandomId(),
-			name: coreTestUtils.generateRandomSlug(),
-			slug: coreTestUtils.generateRandomSlug({
+			id: autumndbTestUtils.generateRandomId(),
+			name: autumndbTestUtils.generateRandomSlug(),
+			slug: autumndbTestUtils.generateRandomSlug({
 				prefix: 'ping',
 			}),
 			type: 'ping@1.0.0',
@@ -43,11 +43,11 @@ describe('action-ping', () => {
 		// Create request using ping contract
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				slug: ping.slug,
 			},

--- a/test/integration/actions/action-request-password-reset.spec.ts
+++ b/test/integration/actions/action-request-password-reset.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { PASSWORDLESS_USER_HASH } from '../../../lib/actions/constants';
@@ -63,7 +63,7 @@ function nockRequest() {
 describe('action-request-password-reset', () => {
 	test('should create a password reset card and user link when arguments match a valid user', async () => {
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -112,7 +112,7 @@ describe('action-request-password-reset', () => {
 	test('should send a password-reset email when the username in the argument matches a valid user', async () => {
 		mailBody = '';
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -179,7 +179,7 @@ describe('action-request-password-reset', () => {
 
 	test('should fail silently if the username does not match a user', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -195,7 +195,7 @@ describe('action-request-password-reset', () => {
 			card: user.id,
 			type: user.type,
 			arguments: {
-				username: coreTestUtils.generateRandomSlug(),
+				username: autumndbTestUtils.generateRandomSlug(),
 			},
 		});
 		expect(requestPasswordReset.error).toBe(false);
@@ -231,7 +231,7 @@ describe('action-request-password-reset', () => {
 
 	test('should fail silently if the user is inactive', async () => {
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		const session = await ctx.createSession(user);
 		await ctx.createLinkThroughWorker(
@@ -269,7 +269,7 @@ describe('action-request-password-reset', () => {
 
 	test('should fail silently if the user does not have a hash', async () => {
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username, PASSWORDLESS_USER_HASH);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -322,7 +322,7 @@ describe('action-request-password-reset', () => {
 
 	test('should invalidate previous password reset requests', async () => {
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -392,8 +392,8 @@ describe('action-request-password-reset', () => {
 
 	test('should not invalidate previous password reset requests from other users', async () => {
 		nockRequest();
-		const firstUsername = coreTestUtils.generateRandomSlug();
-		const secondUsername = coreTestUtils.generateRandomSlug();
+		const firstUsername = autumndbTestUtils.generateRandomSlug();
+		const secondUsername = autumndbTestUtils.generateRandomSlug();
 		const firstUser = await ctx.createUser(firstUsername);
 		const secondUser = await ctx.createUser(secondUsername);
 		await ctx.createLinkThroughWorker(
@@ -474,9 +474,9 @@ describe('action-request-password-reset', () => {
 
 	test('accounts with the same password have different request tokens', async () => {
 		nockRequest();
-		const password = coreTestUtils.generateRandomId().split('-')[0];
-		const firstUsername = coreTestUtils.generateRandomId().split('-')[0];
-		const secondUsername = coreTestUtils.generateRandomId().split('-')[0];
+		const password = autumndbTestUtils.generateRandomId().split('-')[0];
+		const firstUsername = autumndbTestUtils.generateRandomId().split('-')[0];
+		const secondUsername = autumndbTestUtils.generateRandomId().split('-')[0];
 
 		// TODO: temporary workaround for context/logContext mismatch
 		const firstUserCreate = (await ctx.worker.pre(ctx.session, {
@@ -586,7 +586,7 @@ describe('action-request-password-reset', () => {
 	test('should successfully send an email to a user with an array of emails', async () => {
 		mailBody = '';
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -597,8 +597,8 @@ describe('action-request-password-reset', () => {
 			'has member',
 		);
 		const emails = [
-			`${coreTestUtils.generateRandomSlug()}@example.com`,
-			`${coreTestUtils.generateRandomSlug()}@example.com`,
+			`${autumndbTestUtils.generateRandomSlug()}@example.com`,
+			`${autumndbTestUtils.generateRandomSlug()}@example.com`,
 		];
 
 		// Update user emails
@@ -636,7 +636,7 @@ describe('action-request-password-reset', () => {
 
 	test('should throw error when provided username is an email address', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 
 		await expect(
 			ctx.processAction(ctx.session, {

--- a/test/integration/actions/action-send-email.spec.ts
+++ b/test/integration/actions/action-send-email.spec.ts
@@ -1,7 +1,7 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -19,7 +19,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -51,8 +51,8 @@ describe('action-send-email', () => {
 		const args = {
 			toAddress: 'foo@example.com',
 			fromAddress: 'bar@example.com',
-			subject: coreTestUtils.generateRandomId(),
-			html: coreTestUtils.generateRandomId(),
+			subject: autumndbTestUtils.generateRandomId(),
+			html: autumndbTestUtils.generateRandomId(),
 		};
 		await ctx.processAction(ctx.session, {
 			action: 'action-send-email@1.0.0',

--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -1,11 +1,11 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import {
 	errors as workerErrors,
 	WorkerContext,
 } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionSendFirstTimeLoginLink } from '../../../lib/actions/action-send-first-time-login-link';
@@ -24,7 +24,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 
 	// Get org and add test user as member
@@ -71,7 +71,7 @@ function nockRequest() {
 
 describe('action-send-first-time-login-link', () => {
 	test('should throw an error if the user does not have an email address', async () => {
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		user.data.email = [];
 
 		await expect(
@@ -88,7 +88,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('should create a first-time login contract for a user', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -135,7 +135,7 @@ describe('action-send-first-time-login-link', () => {
 	test('should send a first-time-login email to a user', async () => {
 		mailBody = '';
 		nockRequest();
-		const username = coreTestUtils.generateRandomSlug();
+		const username = autumndbTestUtils.generateRandomSlug();
 		const user = await ctx.createUser(username);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -200,7 +200,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('should throw error if the user is inactive', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		const session = await ctx.createSession(user);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
@@ -235,7 +235,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('should invalidate previous first-time logins', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -302,8 +302,12 @@ describe('action-send-first-time-login-link', () => {
 
 	test('should not invalidate previous first-time logins from other users', async () => {
 		nockRequest();
-		const firstUser = await ctx.createUser(coreTestUtils.generateRandomSlug());
-		const secondUser = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const firstUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+		);
+		const secondUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+		);
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -377,7 +381,7 @@ describe('action-send-first-time-login-link', () => {
 	test('successfully sends an email to a user with an array of emails', async () => {
 		mailBody = '';
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -387,8 +391,8 @@ describe('action-send-first-time-login-link', () => {
 			'has member',
 		);
 		const emails = [
-			`${coreTestUtils.generateRandomSlug()}@example.com`,
-			`${coreTestUtils.generateRandomSlug()}@example.com`,
+			`${autumndbTestUtils.generateRandomSlug()}@example.com`,
+			`${autumndbTestUtils.generateRandomSlug()}@example.com`,
 		];
 
 		// Update user emails
@@ -425,7 +429,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('throws an error when the first-time-login user has no org', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 
 		await expect(
 			ctx.processAction(ctx.session, {
@@ -440,9 +444,11 @@ describe('action-send-first-time-login-link', () => {
 
 	test('throws an error when the first-time-login requester has no org', async () => {
 		nockRequest();
-		const requester = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const requester = await ctx.createUser(
+			autumndbTestUtils.generateRandomSlug(),
+		);
 		const requesterSession = await ctx.createSession(requester);
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -469,10 +475,10 @@ describe('action-send-first-time-login-link', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'org@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{},
 		);
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -495,7 +501,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('community role is added to a supplied user with no role set', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -544,7 +550,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('roles should be set to community role when community role is not present', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -593,7 +599,7 @@ describe('action-send-first-time-login-link', () => {
 
 	test('roles should not be updated when community role is present', async () => {
 		nockRequest();
-		const user = await ctx.createUser(coreTestUtils.generateRandomSlug());
+		const user = await ctx.createUser(autumndbTestUtils.generateRandomSlug());
 		await ctx.createLinkThroughWorker(
 			ctx.adminUserId,
 			ctx.session,
@@ -642,9 +648,11 @@ describe('action-send-first-time-login-link', () => {
 	});
 
 	test('users with the "user-community" role cannot send a first-time login link to another user', async () => {
-		const targetUser = await ctx.createUser(coreTestUtils.generateRandomId());
+		const targetUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+		);
 		const communityUser = await ctx.createUser(
-			coreTestUtils.generateRandomId(),
+			autumndbTestUtils.generateRandomId(),
 		);
 		const session = await ctx.createSession(communityUser);
 		await ctx.createLinkThroughWorker(

--- a/test/integration/actions/action-set-update.spec.ts
+++ b/test/integration/actions/action-set-update.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isArray, isNull } from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 import { actionSetUpdate } from '../../../lib/actions/action-set-update';
@@ -15,7 +15,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -28,7 +28,7 @@ describe('action-set-update', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 				tags: ['foo'],
@@ -37,11 +37,11 @@ describe('action-set-update', () => {
 
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				property: ['data', 'tags'],
 				value: ['bar'],
@@ -72,7 +72,7 @@ describe('action-set-update', () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
 			ctx.session,
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				status: 'open',
 				tags: ['foo'],
@@ -81,11 +81,11 @@ describe('action-set-update', () => {
 
 		const request: any = {
 			context: {
-				id: `TEST-${coreTestUtils.generateRandomId()}`,
+				id: `TEST-${autumndbTestUtils.generateRandomId()}`,
 			},
 			timestamp: new Date().toISOString(),
 			actor: ctx.adminUserId,
-			originator: coreTestUtils.generateRandomId(),
+			originator: autumndbTestUtils.generateRandomId(),
 			arguments: {
 				property: 'data.tags',
 				value: ['bar'],

--- a/test/integration/actions/action-set-user-avatar.spec.ts
+++ b/test/integration/actions/action-set-user-avatar.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import md5 from 'blueimp-md5';
 import { isArray, isNull } from 'lodash';
 import nock from 'nock';
@@ -18,7 +18,7 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 });
 
@@ -37,7 +37,7 @@ afterEach(() => {
  * @returns random email address
  */
 function genEmail(): string {
-	return `${coreTestUtils.generateRandomId()}@foo.bar`;
+	return `${autumndbTestUtils.generateRandomId()}@foo.bar`;
 }
 
 describe('action-set-user-avatar', () => {
@@ -46,9 +46,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 			},
 		);
@@ -81,11 +81,11 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
-				avatar: coreTestUtils.generateRandomId(),
+				avatar: autumndbTestUtils.generateRandomId(),
 			},
 		);
 
@@ -116,9 +116,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: genEmail(),
 			},
@@ -155,9 +155,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: [genEmail(), genEmail()],
 			},
@@ -197,9 +197,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: genEmail(),
 			},
@@ -238,9 +238,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: [genEmail(), genEmail()],
 			},
@@ -282,9 +282,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: [genEmail(), genEmail()],
 			},
@@ -326,9 +326,9 @@ describe('action-set-user-avatar', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'user@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
-				hash: coreTestUtils.generateRandomId(),
+				hash: autumndbTestUtils.generateRandomId(),
 				roles: [],
 				email: genEmail(),
 				avatar: null,

--- a/test/integration/actions/helpers.ts
+++ b/test/integration/actions/helpers.ts
@@ -1,11 +1,11 @@
-import { Kernel, testUtils as coreTestUtils } from 'autumndb';
-import type { ActionData } from '@balena/jellyfish-types/build/core';
+import type { ActionData } from '@balena/jellyfish-queue';
 import {
 	ActionContractDefinition,
 	ActionHandlerRequest,
 	ActionPreRequest,
 	testUtils as workerTestUtils,
 } from '@balena/jellyfish-worker';
+import { Kernel, testUtils as autumndbTestUtils } from 'autumndb';
 import { v4 as uuidv4 } from 'uuid';
 
 export function makeHandlerRequest(
@@ -14,7 +14,7 @@ export function makeHandlerRequest(
 	requestArguments = {},
 ): ActionHandlerRequest {
 	const contract = {
-		id: coreTestUtils.generateRandomId(),
+		id: autumndbTestUtils.generateRandomId(),
 		...Kernel.defaults<ActionData>(actionContract),
 	};
 
@@ -39,7 +39,7 @@ export function makePreRequest(
 ): ActionPreRequest {
 	return {
 		action: actionContract.slug,
-		card: options.card || coreTestUtils.generateRandomId(),
+		card: options.card || autumndbTestUtils.generateRandomId(),
 		type: options.type || 'card@1.0.0',
 		logContext: context.logContext,
 		arguments: options.requestArguments || {},

--- a/test/integration/actions/integrations/foobar.ts
+++ b/test/integration/actions/integrations/foobar.ts
@@ -1,8 +1,8 @@
-import { Kernel } from 'autumndb';
 import type {
 	Integration,
 	IntegrationDefinition,
 } from '@balena/jellyfish-worker';
+import { Kernel } from 'autumndb';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/test/integration/actions/mirror.spec.ts
+++ b/test/integration/actions/mirror.spec.ts
@@ -1,7 +1,7 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { WorkerContext } from '@balena/jellyfish-worker';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isArray, isEmpty } from 'lodash';
 import sinon from 'sinon';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -21,13 +21,13 @@ beforeAll(async () => {
 		plugins: [productOsPlugin(), defaultPlugin(), foobarPlugin()],
 	});
 	actionContext = ctx.worker.getActionContext({
-		id: `test-${coreTestUtils.generateRandomId()}`,
+		id: `test-${autumndbTestUtils.generateRandomId()}`,
 	});
 
 	supportThread = await ctx.createSupportThread(
 		ctx.adminUserId,
 		ctx.session,
-		coreTestUtils.generateRandomSlug(),
+		autumndbTestUtils.generateRandomSlug(),
 		{
 			status: 'open',
 		},
@@ -48,17 +48,17 @@ describe('mirror()', () => {
 			ctx.adminUserId,
 			ctx.session,
 			'external-event@1.0.0',
-			coreTestUtils.generateRandomSlug(),
+			autumndbTestUtils.generateRandomSlug(),
 			{
 				source,
 				headers: {
-					foo: coreTestUtils.generateRandomId(),
+					foo: autumndbTestUtils.generateRandomId(),
 				},
 				payload: {
-					bar: coreTestUtils.generateRandomId(),
+					bar: autumndbTestUtils.generateRandomId(),
 				},
 				data: {
-					baz: coreTestUtils.generateRandomId(),
+					baz: autumndbTestUtils.generateRandomId(),
 				},
 			},
 		);

--- a/test/integration/contracts/role-user-community.spec.ts
+++ b/test/integration/contracts/role-user-community.spec.ts
@@ -1,5 +1,5 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 
@@ -12,7 +12,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 
@@ -38,7 +38,9 @@ describe('role-user-community', () => {
 	});
 
 	test('users should not be able to view messages on threads they cannot view', async () => {
-		const otherUser = await ctx.createUser(coreTestUtils.generateRandomId());
+		const otherUser = await ctx.createUser(
+			autumndbTestUtils.generateRandomId(),
+		);
 		expect(otherUser.data.roles).toEqual(['user-community']);
 		const otherUserSession = await ctx.createSession(otherUser);
 

--- a/test/integration/contracts/role-user-external-support.spec.ts
+++ b/test/integration/contracts/role-user-external-support.spec.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import _ from 'lodash';
 import { defaultPlugin, testUtils } from '../../../lib';
 
@@ -11,8 +11,8 @@ let testOrg: any;
 async function createUser(roles: string[], org: any): Promise<any> {
 	// Create user
 	const user = await ctx.createUser(
-		coreTestUtils.generateRandomId(),
-		coreTestUtils.generateRandomId(),
+		autumndbTestUtils.generateRandomId(),
+		autumndbTestUtils.generateRandomId(),
 		roles,
 	);
 

--- a/test/integration/contracts/support-thread.spec.ts
+++ b/test/integration/contracts/support-thread.spec.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -12,7 +12,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 
@@ -127,7 +127,7 @@ test('should evaluate the last message in a support thread', async () => {
 			{
 				op: 'replace',
 				path: '/name',
-				value: `Thread ${coreTestUtils.generateRandomId()}`,
+				value: `Thread ${autumndbTestUtils.generateRandomId()}`,
 			},
 		],
 	);

--- a/test/integration/contracts/triggered-action-increment-tag.spec.ts
+++ b/test/integration/contracts/triggered-action-increment-tag.spec.ts
@@ -1,7 +1,7 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import type { Contract } from '@balena/jellyfish-types/build/core';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -14,7 +14,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 
@@ -46,7 +46,7 @@ test('should sanely handle line breaks before tags in messages/whispers', async 
 		'foobar',
 		{},
 	);
-	const tagName = coreTestUtils.generateRandomSlug({
+	const tagName = autumndbTestUtils.generateRandomSlug({
 		prefix: 'test-tag',
 	});
 
@@ -88,13 +88,13 @@ test('should sanely handle multiple tags in messages/whispers', async () => {
 		'foobar',
 		{},
 	);
-	const tagName1 = coreTestUtils.generateRandomSlug({
+	const tagName1 = autumndbTestUtils.generateRandomSlug({
 		prefix: 'test-tag',
 	});
-	const tagName2 = coreTestUtils.generateRandomSlug({
+	const tagName2 = autumndbTestUtils.generateRandomSlug({
 		prefix: 'test-tag',
 	});
-	const tagName3 = coreTestUtils.generateRandomSlug({
+	const tagName3 = autumndbTestUtils.generateRandomSlug({
 		prefix: 'test-tag',
 	});
 
@@ -181,7 +181,7 @@ test('should create a new tag when one is found in a message', async () => {
 		'foobar',
 		{},
 	);
-	const tagName = coreTestUtils.generateRandomSlug({
+	const tagName = autumndbTestUtils.generateRandomSlug({
 		prefix: 'test-tag',
 	});
 

--- a/test/integration/contracts/triggered-action-support-completed-improvement-reopen.spec.ts
+++ b/test/integration/contracts/triggered-action-support-completed-improvement-reopen.spec.ts
@@ -1,5 +1,5 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -11,7 +11,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 

--- a/test/integration/contracts/triggered-action-support-reopen.spec.ts
+++ b/test/integration/contracts/triggered-action-support-reopen.spec.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -12,7 +12,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 

--- a/test/integration/contracts/triggered-action-support-summary.spec.ts
+++ b/test/integration/contracts/triggered-action-support-summary.spec.ts
@@ -1,5 +1,5 @@
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -11,7 +11,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 

--- a/test/integration/contracts/triggered-action-update-event-edited-at.spec.ts
+++ b/test/integration/contracts/triggered-action-update-event-edited-at.spec.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { isBefore, isValid } from 'date-fns';
 import { defaultPlugin, testUtils } from '../../../lib';
 
@@ -13,7 +13,7 @@ beforeAll(async () => {
 		plugins: [defaultPlugin(), productOsPlugin()],
 	});
 
-	user = await ctx.createUser(coreTestUtils.generateRandomId());
+	user = await ctx.createUser(autumndbTestUtils.generateRandomId());
 	session = await ctx.createSession(user);
 });
 
@@ -25,20 +25,20 @@ test('editing a message triggers an update to the edited_at field', async () => 
 	const supportThread = await ctx.createSupportThread(
 		user.id,
 		session.id,
-		coreTestUtils.generateRandomId(),
+		autumndbTestUtils.generateRandomId(),
 		{
 			status: 'open',
 		},
 	);
-	const update1 = coreTestUtils.generateRandomId();
-	const update2 = coreTestUtils.generateRandomId();
+	const update1 = autumndbTestUtils.generateRandomId();
+	const update2 = autumndbTestUtils.generateRandomId();
 
 	// Verify that initial the edited_at field is undefined
 	const message = await ctx.createMessage(
 		user.id,
 		session.id,
 		supportThread,
-		coreTestUtils.generateRandomId(),
+		autumndbTestUtils.generateRandomId(),
 	);
 	expect(typeof message.data.edited_at).toEqual('undefined');
 
@@ -111,12 +111,12 @@ test('updating a meta field in the message payload triggers an update to the edi
 	const supportThread = await ctx.createSupportThread(
 		user.id,
 		session.id,
-		coreTestUtils.generateRandomId(),
+		autumndbTestUtils.generateRandomId(),
 		{
 			status: 'open',
 		},
 	);
-	const mentionedUserSlug = coreTestUtils.generateRandomSlug({
+	const mentionedUserSlug = autumndbTestUtils.generateRandomSlug({
 		prefix: 'user',
 	});
 

--- a/test/integration/contracts/triggered-action-user-contact.spec.ts
+++ b/test/integration/contracts/triggered-action-user-contact.spec.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
-import { testUtils as coreTestUtils } from 'autumndb';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
+import { strict as assert } from 'assert';
+import { testUtils as autumndbTestUtils } from 'autumndb';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;
@@ -16,7 +16,7 @@ afterAll(() => {
 });
 
 test('The contact is updated when the user is updated', async () => {
-	const username = coreTestUtils.generateRandomId();
+	const username = autumndbTestUtils.generateRandomId();
 
 	const inserted = await ctx.worker.insertCard(
 		ctx.logContext,
@@ -28,7 +28,7 @@ test('The contact is updated when the user is updated', async () => {
 		},
 		{
 			name: username,
-			slug: coreTestUtils.generateRandomSlug({
+			slug: autumndbTestUtils.generateRandomSlug({
 				prefix: 'user',
 			}),
 			version: '1.0.0',
@@ -110,7 +110,7 @@ test('The contact is updated when the user is updated', async () => {
 
 test('The contact is updated when user tags are updated', async () => {
 	// Insert a new user and check that a contact is created.
-	const username = coreTestUtils.generateRandomId();
+	const username = autumndbTestUtils.generateRandomId();
 	const firstTag = 'foo';
 	let user = await ctx.worker.insertCard(
 		ctx.logContext,
@@ -122,7 +122,7 @@ test('The contact is updated when user tags are updated', async () => {
 		},
 		{
 			name: username,
-			slug: coreTestUtils.generateRandomSlug({
+			slug: autumndbTestUtils.generateRandomSlug({
 				prefix: 'user',
 			}),
 			version: '1.0.0',

--- a/test/integration/contracts/user-guest.spec.ts
+++ b/test/integration/contracts/user-guest.spec.ts
@@ -1,6 +1,6 @@
+import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { strict as assert } from 'assert';
 import { Kernel } from 'autumndb';
-import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { defaultPlugin, testUtils } from '../../../lib';
 
 let ctx: testUtils.TestContext;


### PR DESCRIPTION
Move away from jellyfish-types.
Stop using core alias for autumndb imports.
Alphabetize imports.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>