### PR TITLE
Nock all Google Meet tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ You can also run tests locally against Postgres and Redis instances running in `
 ```
 git secret reveal -f
 npm run compose
-export INTEGRATION_GOOGLE_MEET_CREDENTIALS=$(cat .balena/secrets/integration_google_meet_credentials)
 REDIS_HOST=localhost POSTGRES_HOST=localhost npx jest test/integration/actions/action-ping.spec.ts
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,5 @@
 version: '3'
 
-env:
-  INTEGRATION_GOOGLE_MEET_CREDENTIALS:
-    sh: cat /run/secrets/integration_google_meet_credentials
-
 tasks:
   test:
     cmds:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,11 +11,5 @@ services:
       - redis
     environment:
       - LOGLEVEL=error
-    secrets:
-      - integration_google_meet_credentials
     networks:
       - internal
-
-secrets:
-  integration_google_meet_credentials:
-    file: ./.balena/secrets/integration_google_meet_credentials

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.24",
-    "@balena/jellyfish-environment": "^9.1.12",
+    "@balena/jellyfish-environment": "^9.1.13",
     "@balena/jellyfish-logger": "^5.0.19",
     "@balena/jellyfish-worker": "^21.2.6",
     "autumndb": "^19.1.19",
@@ -57,7 +57,6 @@
     "date-fns": "^2.28.0",
     "form-data": "^4.0.0",
     "googleapis": "^97.0.0",
-    "is-base64": "^1.1.0",
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.21",
     "semver": "^7.3.5",

--- a/test/integration/actions/action-google-meet.spec.ts
+++ b/test/integration/actions/action-google-meet.spec.ts
@@ -116,29 +116,6 @@ describe('action-google-meet', () => {
 		).rejects.toThrow(new Error(`No such type: ${message.type}`));
 	});
 
-	test('should return a conference URL', async () => {
-		const supportThread = await ctx.createSupportThread(
-			ctx.adminUserId,
-			ctx.session,
-			autumndbTestUtils.generateRandomSlug(),
-			{
-				status: 'open',
-			},
-		);
-
-		const result = await ctx.processAction(ctx.session, {
-			action: 'action-google-meet@1.0.0',
-			logContext: ctx.logContext,
-			card: supportThread.id,
-			type: supportThread.type,
-			arguments: {},
-		});
-
-		expect(
-			result.data.conferenceUrl.startsWith('https://meet.google.com'),
-		).toBe(true);
-	});
-
 	test('should update the card with the conference URL', async () => {
 		const supportThread = await ctx.createSupportThread(
 			ctx.adminUserId,
@@ -148,6 +125,11 @@ describe('action-google-meet', () => {
 				status: 'open',
 			},
 		);
+
+		stub({
+			hangoutLink: 'https://meet.google.com',
+			id: autumndbTestUtils.generateRandomId(),
+		});
 
 		await ctx.processAction(ctx.session, {
 			action: 'action-google-meet@1.0.0',


### PR DESCRIPTION
We now no longer need to account for
Google Meet credentials being provided
through env vars as base64. We were doing
this for tests only, but will now use a
default dummy value for tests.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>