### PR TITLE
Add mirror actions to external support role

### DIFF
--- a/lib/contracts/role-user-external-support.ts
+++ b/lib/contracts/role-user-external-support.ts
@@ -152,6 +152,9 @@ export const roleUserExternalSupport: RoleContractDefinition = {
 								'action-update-card',
 								'action-create-event',
 								'action-oauth-associate',
+								'action-integration-discourse-mirror-event',
+								'action-integration-front-mirror-event',
+								'action-integration-github-mirror-event',
 							],
 						},
 						type: {


### PR DESCRIPTION
Give access to mirror actions to users with the
external support role. Some actions executed by
these users trigger mirrors and there is no reason
they should not be able to execute triggered mirrors.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>