### PR TITLE
action-request-password-reset: Use crypto.randomBytes for reset token

### DIFF
--- a/lib/actions/action-request-password-reset.ts
+++ b/lib/actions/action-request-password-reset.ts
@@ -174,7 +174,7 @@ export async function addPasswordResetCard(
 	request: ActionHandlerRequest,
 	typeCard: TypeContract,
 ): Promise<Contract> {
-	const resetToken = crypto.randomBytes(48).toString('hex');
+	const resetToken = crypto.randomBytes(32).toString('hex');
 	const requestedAt = new Date();
 	const hourInFuture = requestedAt.setHours(requestedAt.getHours() + 1);
 	const expiresAt = new Date(hourInFuture);

--- a/lib/actions/action-request-password-reset.ts
+++ b/lib/actions/action-request-password-reset.ts
@@ -15,7 +15,6 @@ import { buildSendEmailOptions } from './mail-utils';
 import { addLinkCard } from './utils';
 
 const logger = getLogger(__filename);
-const sendEmailHandler = actionSendEmail.handler;
 
 /**
  * @summary Get user card by slug
@@ -216,7 +215,7 @@ export async function sendEmail(
 	const username = userCard.slug.replace(/^user-/g, '');
 	const url = `https://jel.ly.fish/password_reset/${resetToken}/${username}`;
 	const html = `<p>Hello,</p><p>We have received a password reset request for the Jellyfish account attached to this email.</p><p>Please use the link below to reset your password:</p><a href="${url}">${url}</a><p>Cheers</p><p>Jellyfish Team</p><a href="https://jel.ly.fish">https://jel.ly.fish</a>`;
-
+	const sendEmailHandler = actionSendEmail.handler;
 	return sendEmailHandler(context.privilegedSession, context, userCard, {
 		arguments: buildSendEmailOptions(
 			userCard,

--- a/lib/actions/action-request-password-reset.ts
+++ b/lib/actions/action-request-password-reset.ts
@@ -1,4 +1,3 @@
-import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { getLogger } from '@balena/jellyfish-logger';
 import type {
 	Contract,
@@ -17,8 +16,6 @@ import { addLinkCard } from './utils';
 
 const logger = getLogger(__filename);
 const sendEmailHandler = actionSendEmail.handler;
-
-const ACTIONS = defaultEnvironment.actions;
 
 /**
  * @summary Get user card by slug
@@ -175,13 +172,9 @@ export async function invalidatePreviousPasswordResets(
 export async function addPasswordResetCard(
 	context: WorkerContext,
 	request: ActionHandlerRequest,
-	user: Contract,
 	typeCard: TypeContract,
 ): Promise<Contract> {
-	const resetToken = crypto
-		.createHmac('sha256', ACTIONS.resetPasswordSecretToken)
-		.update(user.data.hash as crypto.BinaryLike)
-		.digest('hex');
+	const resetToken = crypto.randomBytes(48).toString('hex');
 	const requestedAt = new Date();
 	const hourInFuture = requestedAt.setHours(requestedAt.getHours() + 1);
 	const expiresAt = new Date(hourInFuture);
@@ -288,7 +281,6 @@ const handler: ActionDefinition['handler'] = async (
 		const passwordResetCard = await addPasswordResetCard(
 			context,
 			request,
-			user,
 			typeCard,
 		);
 		await addLinkCard(context, request, passwordResetCard, user);

--- a/test/integration/actions/action-complete-password-reset.spec.ts
+++ b/test/integration/actions/action-complete-password-reset.spec.ts
@@ -4,7 +4,6 @@ import type { WorkerContext } from '@balena/jellyfish-worker';
 import { strict as assert } from 'assert';
 import { testUtils as autumndbTestUtils } from 'autumndb';
 import bcrypt from 'bcrypt';
-import crypto from 'crypto';
 import { isArray, isNull } from 'lodash';
 import nock from 'nock';
 import { defaultPlugin, testUtils } from '../../../lib';
@@ -12,14 +11,31 @@ import { actionCompletePasswordReset } from '../../../lib/actions/action-complet
 import { actionSendEmail } from '../../../lib/actions/action-send-email';
 import { makePreRequest } from './helpers';
 
-const ACTIONS = defaultEnvironment.actions;
 const MAIL_OPTIONS = defaultEnvironment.mail.options;
 let balenaOrg: any;
 const hash = 'foobar';
-const resetToken = crypto
-	.createHmac('sha256', ACTIONS.resetPasswordSecretToken)
-	.update(hash)
-	.digest('hex');
+
+// We grab the resetToken sent by action-request-password-reset by mocking the email sender and extracting it from the email body
+let resetToken: string = 'init';
+actionSendEmail.handler = async (_session, _context, _card, request) => {
+	const { html } = request.arguments;
+	// extract from: https://jel.ly.fish/password_reset/${resetToken}/${username}
+	const passwordResetPattern =
+		/href="https:\/\/jel\.ly\.fish\/password_reset\/(?<resetToken>[0-9a-fA-F]{64})\//;
+
+	const match = passwordResetPattern.exec(html);
+	if (!match || !match.groups) {
+		throw new Error(
+			`Could not extract the resetToken from the email body: ${html}`,
+		);
+	}
+	resetToken = match.groups.resetToken;
+	if (resetToken === 'init') {
+		throw new Error('Failed to recover resetToken');
+	}
+	return null;
+};
+
 const pre = actionCompletePasswordReset.pre;
 let ctx: testUtils.TestContext;
 let actionContext: WorkerContext;
@@ -94,24 +110,6 @@ describe('action-complete-password-reset', () => {
 		const user = await ctx.createUser(username, hash);
 		const session = await ctx.createSession(user);
 
-		// We need the resetToken; it's on the email body
-		// const url = `https://jel.ly.fish/password_reset/${resetToken}/${username}`;
-		let sentResetToken: string = 'init';
-		actionSendEmail.handler = async (_session, _context, _card, request) => {
-			const { html } = request.arguments;
-			const passwordResetPattern =
-				/href="https:\/\/jel\.ly\.fish\/password_reset\/(?<resetToken>[0-9a-fA-F]{64})\//;
-
-			const match = passwordResetPattern.exec(html);
-			if (!match || !match.groups) {
-				throw new Error(
-					`Could not extract the resetToken from the email body: ${html}`,
-				);
-			}
-			sentResetToken = match.groups.resetToken;
-			return null;
-		};
-
 		const passwordReset = await ctx.processAction(ctx.session, {
 			type: 'action-request@1.0.0',
 			data: {
@@ -132,17 +130,13 @@ describe('action-complete-password-reset', () => {
 		});
 		expect(passwordReset.error).toBe(false);
 
-		if (sentResetToken === 'init') {
-			throw new Error('Failed to recover resetToken');
-		}
-
 		const completePasswordReset = (await ctx.worker.pre(ctx.session, {
 			action: 'action-complete-password-reset@1.0.0',
 			logContext: ctx.logContext,
 			card: user.id,
 			type: user.type,
 			arguments: {
-				resetToken: sentResetToken,
+				resetToken,
 				newPassword: autumndbTestUtils.generateRandomId(),
 			},
 		})) as any;


### PR DESCRIPTION
Instead of using a combination of the existing password and a secret env
var, just generate a buffer of random bytes and transform to a hex
string. Much simpler!

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>