### PR TITLE
Improve performance of sync whisper triggered action

### DIFF
--- a/lib/contracts/triggered-action-sync-thread-post-link-whisper.ts
+++ b/lib/contracts/triggered-action-sync-thread-post-link-whisper.ts
@@ -7,13 +7,16 @@ export const triggeredActionSyncThreadPostLinkWhisper: TriggeredActionContractDe
 		name: 'Triggered action for creating a whisper with link on thread sync',
 		markers: [],
 		data: {
-			schedule: 'async',
 			filter: {
 				title: "Support threads created with a 'mirrors' field",
 				$$links: {
 					'is attached to': {
 						type: 'object',
 						properties: {
+							type: {
+								type: 'string',
+								const: 'support-thread@1.0.0',
+							},
 							id: {
 								type: 'string',
 							},


### PR DESCRIPTION
By specifying the type of contract expanded in $$links, this trigger
becomes less likely to require a DB query to validate in the JF worker.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>